### PR TITLE
feat: Status API + External Dispatch plugins (#645, #646)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -49,9 +49,9 @@ if [ -n "$GO_FILES" ]; then
     CHANGED_PKGS=""
     for f in $GO_FILES; do
         pkg_dir=$(dirname "$f")
-        # Skip web/ and cmd/server/ — web/ requires go:embed dist/* from
-        # frontend build, and cmd/server/ transitively imports web/
-        if echo "$pkg_dir" | grep -qE '^(web|cmd/server)(/|$)'; then continue; fi
+        # Skip packages that depend on web/ — it requires go:embed dist/*
+        # from the frontend build (handled by CI, not pre-commit)
+        if echo "$pkg_dir" | grep -qE '^(web|cmd/server|server/router)(/|$)'; then continue; fi
         pkg="go.woodpecker-ci.org/woodpecker/v3/${pkg_dir}"
         if ! echo "$CHANGED_PKGS" | grep -qF "$pkg"; then
             CHANGED_PKGS="$CHANGED_PKGS $pkg"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,3 +6,4 @@
 - Add pipeline lifecycle event emission at all lifecycle points: created, pending, started, completed, failed, killed, step.completed (#643)
 - Add GCP Pub/Sub plugin: publishes pipeline events to ci-events topic with sidecar-compatible schema_version "1.0" format (#644)
 - Add Status API plugin: REST endpoints for external agents to report workflow init/update/done with bearer token auth (#645)
+- Add External Dispatch plugin: intercepts queue task assignment, publishes task.available events for external agent dispatch via WebSocket (#646)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,4 @@
 - Add plugin architecture core framework: EventHook, StatusHook, DispatchHook interfaces with registry and channel-based event bus (#642)
 - Add pipeline lifecycle event emission at all lifecycle points: created, pending, started, completed, failed, killed, step.completed (#643)
 - Add GCP Pub/Sub plugin: publishes pipeline events to ci-events topic with sidecar-compatible schema_version "1.0" format (#644)
+- Add Status API plugin: REST endpoints for external agents to report workflow init/update/done with bearer token auth (#645)

--- a/cmd/server/flags.go
+++ b/cmd/server/flags.go
@@ -621,6 +621,11 @@ var flags = append([]cli.Flag{
 		Usage:   "Pub/Sub topic name for pipeline events",
 		Value:   "ci-events",
 	},
+	&cli.StringFlag{
+		Sources: cli.EnvVars("WOODPECKER_PLUGIN_STATUS_API_TOKEN"),
+		Name:    "plugin-status-api-token",
+		Usage:   "Bearer token for the status API plugin endpoints",
+	},
 }, logger.GlobalLoggerFlags...)
 
 // If woodpecker is running inside a container the default value for

--- a/cmd/server/setup_plugins.go
+++ b/cmd/server/setup_plugins.go
@@ -23,6 +23,7 @@ import (
 
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/plugin"
+	"go.woodpecker-ci.org/woodpecker/v3/server/plugin/externaldispatch"
 	"go.woodpecker-ci.org/woodpecker/v3/server/plugin/gcppubsub"
 	"go.woodpecker-ci.org/woodpecker/v3/server/plugin/statusapi"
 )
@@ -59,7 +60,8 @@ func loadPlugin(ctx context.Context, name string, c *cli.Command, registry *plug
 		return loadGCPPubSub(ctx, c, registry)
 	case "status-api":
 		return loadStatusAPI(c, registry)
-	// Phase 5: case "external-dispatch":
+	case "external-dispatch":
+		return loadExternalDispatch(registry)
 	default:
 		return fmt.Errorf("unknown plugin: %s", name)
 	}
@@ -91,5 +93,18 @@ func loadStatusAPI(c *cli.Command, registry *plugin.Registry) error {
 	handler := statusapi.New(token)
 	registry.RegisterStatusHook(handler)
 	log.Info().Msg("status-api plugin loaded")
+	return nil
+}
+
+func loadExternalDispatch(registry *plugin.Registry) error {
+	dispatcher := externaldispatch.New(registry)
+	registry.RegisterDispatchHook(dispatcher)
+
+	// Wire the dispatch hook into the queue
+	if q := server.Config.Services.Queue; q != nil {
+		q.SetDispatchHook(dispatcher.Dispatch)
+	}
+
+	log.Info().Msg("external-dispatch plugin loaded")
 	return nil
 }

--- a/cmd/server/setup_plugins.go
+++ b/cmd/server/setup_plugins.go
@@ -24,6 +24,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server"
 	"go.woodpecker-ci.org/woodpecker/v3/server/plugin"
 	"go.woodpecker-ci.org/woodpecker/v3/server/plugin/gcppubsub"
+	"go.woodpecker-ci.org/woodpecker/v3/server/plugin/statusapi"
 )
 
 // setupPlugins initializes the plugin registry, event bus, and
@@ -56,7 +57,8 @@ func loadPlugin(ctx context.Context, name string, c *cli.Command, registry *plug
 	switch name {
 	case "gcppubsub":
 		return loadGCPPubSub(ctx, c, registry)
-	// Phase 4: case "status-api":
+	case "status-api":
+		return loadStatusAPI(c, registry)
 	// Phase 5: case "external-dispatch":
 	default:
 		return fmt.Errorf("unknown plugin: %s", name)
@@ -77,5 +79,17 @@ func loadGCPPubSub(ctx context.Context, c *cli.Command, registry *plugin.Registr
 
 	registry.RegisterEventHook(pub)
 	log.Info().Str("project", project).Str("topic", topic).Msg("gcppubsub plugin loaded")
+	return nil
+}
+
+func loadStatusAPI(c *cli.Command, registry *plugin.Registry) error {
+	token := c.String("plugin-status-api-token")
+	if token == "" {
+		return fmt.Errorf("status-api plugin requires WOODPECKER_PLUGIN_STATUS_API_TOKEN")
+	}
+
+	handler := statusapi.New(token)
+	registry.RegisterStatusHook(handler)
+	log.Info().Msg("status-api plugin loaded")
 	return nil
 }

--- a/server/plugin/externaldispatch/dispatch.go
+++ b/server/plugin/externaldispatch/dispatch.go
@@ -1,0 +1,62 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externaldispatch
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/plugin"
+)
+
+// Dispatcher implements plugin.DispatchHook by claiming all pending tasks
+// for external dispatch. It publishes a task.available event to the event
+// bus so that external systems (e.g. scaler → WebSocket → agent) can pick
+// up the work. Agents report back via the Status API plugin.
+type Dispatcher struct {
+	registry *plugin.Registry
+}
+
+// New creates a Dispatcher that publishes task events to the given registry's bus.
+func New(registry *plugin.Registry) *Dispatcher {
+	return &Dispatcher{registry: registry}
+}
+
+func (d *Dispatcher) Name() string { return "external-dispatch" }
+
+// Dispatch claims a task for external handling and emits a task.available event.
+// The queue moves the task to running; external agents complete it via Status API.
+func (d *Dispatcher) Dispatch(_ context.Context, task *model.Task) (bool, error) {
+	bus := d.registry.GetEventBus()
+	if bus == nil {
+		log.Warn().Str("task", task.ID).Msg("external-dispatch: no event bus, skipping")
+		return false, nil
+	}
+
+	bus.Publish(plugin.PipelineEvent{
+		Type:       plugin.EventTaskAvailable,
+		PipelineID: task.PipelineID,
+		RepoID:     task.RepoID,
+		Timestamp:  time.Now(),
+	})
+
+	log.Debug().Str("task", task.ID).Msg("external-dispatch: task claimed")
+	return true, nil
+}
+
+func (d *Dispatcher) Close() error { return nil }

--- a/server/plugin/externaldispatch/dispatch_test.go
+++ b/server/plugin/externaldispatch/dispatch_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package externaldispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/plugin"
+)
+
+type recordingHook struct {
+	events []plugin.PipelineEvent
+}
+
+func (h *recordingHook) Name() string { return "recorder" }
+func (h *recordingHook) OnEvent(_ context.Context, event plugin.PipelineEvent) error {
+	h.events = append(h.events, event)
+	return nil
+}
+func (h *recordingHook) Close() error { return nil }
+
+func TestName(t *testing.T) {
+	d := New(plugin.NewRegistry())
+	assert.Equal(t, "external-dispatch", d.Name())
+}
+
+func TestClose(t *testing.T) {
+	d := New(plugin.NewRegistry())
+	assert.NoError(t, d.Close())
+}
+
+func TestDispatchPublishesEvent(t *testing.T) {
+	registry := plugin.NewRegistry()
+	bus := plugin.NewEventBus(context.Background())
+	registry.SetEventBus(bus)
+
+	recorder := &recordingHook{}
+	registry.RegisterEventHook(recorder)
+
+	d := New(registry)
+	task := &model.Task{ID: "42", PipelineID: 10, RepoID: 100}
+
+	handled, err := d.Dispatch(context.Background(), task)
+	require.NoError(t, err)
+	assert.True(t, handled)
+
+	// Give the async delivery a moment
+	time.Sleep(50 * time.Millisecond)
+
+	require.Len(t, recorder.events, 1)
+	assert.Equal(t, plugin.EventTaskAvailable, recorder.events[0].Type)
+	assert.Equal(t, int64(10), recorder.events[0].PipelineID)
+	assert.Equal(t, int64(100), recorder.events[0].RepoID)
+}
+
+func TestDispatchWithoutBus(t *testing.T) {
+	registry := plugin.NewRegistry()
+	// No event bus set
+
+	d := New(registry)
+	task := &model.Task{ID: "42"}
+
+	handled, err := d.Dispatch(context.Background(), task)
+	require.NoError(t, err)
+	assert.False(t, handled, "should not claim task without event bus")
+}
+
+func TestDispatchMultipleTasks(t *testing.T) {
+	registry := plugin.NewRegistry()
+	bus := plugin.NewEventBus(context.Background())
+	registry.SetEventBus(bus)
+
+	recorder := &recordingHook{}
+	registry.RegisterEventHook(recorder)
+
+	d := New(registry)
+
+	for i := 1; i <= 3; i++ {
+		task := &model.Task{ID: string(rune('0' + i)), PipelineID: int64(i * 10)}
+		handled, err := d.Dispatch(context.Background(), task)
+		require.NoError(t, err)
+		assert.True(t, handled)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Len(t, recorder.events, 3)
+}

--- a/server/plugin/interfaces.go
+++ b/server/plugin/interfaces.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
-	"go.woodpecker-ci.org/woodpecker/v3/server/store"
 )
 
 // EventType identifies the kind of pipeline lifecycle event.
@@ -65,9 +64,10 @@ type EventHook interface {
 
 // StatusHook registers REST endpoints for external status updates.
 // Each StatusHook owns a sub-path under /api/plugins/<name>/.
+// Handlers should use store.FromContext(c) to access the database.
 type StatusHook interface {
 	Name() string
-	RegisterRoutes(group *gin.RouterGroup, store store.Store)
+	RegisterRoutes(group *gin.RouterGroup)
 	Close() error
 }
 

--- a/server/plugin/interfaces.go
+++ b/server/plugin/interfaces.go
@@ -34,6 +34,7 @@ const (
 	EventPipelineFailed    EventType = "pipeline.failed"
 	EventPipelineKilled    EventType = "pipeline.killed"
 	EventStepCompleted     EventType = "step.completed"
+	EventTaskAvailable     EventType = "task.available"
 )
 
 // PipelineEvent carries data about a pipeline lifecycle transition.

--- a/server/plugin/registry_test.go
+++ b/server/plugin/registry_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
-	"go.woodpecker-ci.org/woodpecker/v3/server/store"
 )
 
 // mock implementations for testing
@@ -50,8 +49,8 @@ type mockStatusHook struct {
 	closed     bool
 }
 
-func (m *mockStatusHook) Name() string                                      { return m.name }
-func (m *mockStatusHook) RegisterRoutes(_ *gin.RouterGroup, _ store.Store) { m.registered = true }
+func (m *mockStatusHook) Name() string                      { return m.name }
+func (m *mockStatusHook) RegisterRoutes(_ *gin.RouterGroup) { m.registered = true }
 func (m *mockStatusHook) Close() error {
 	m.closed = true
 	return nil

--- a/server/plugin/statusapi/endpoints.go
+++ b/server/plugin/statusapi/endpoints.go
@@ -1,0 +1,168 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusapi
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+
+	"go.woodpecker-ci.org/woodpecker/v3/rpc"
+	"go.woodpecker-ci.org/woodpecker/v3/server"
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/pipeline"
+	"go.woodpecker-ci.org/woodpecker/v3/server/plugin"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+)
+
+// handleInit transitions a workflow from pending to running.
+// Equivalent to RPC.Init() but without agent context.
+func handleInit(c *gin.Context) {
+	_store := store.FromContext(c)
+	if _store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "store not available"})
+		return
+	}
+	workflowID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workflow id"})
+		return
+	}
+
+	var state rpc.WorkflowState
+	if err := c.ShouldBindJSON(&state); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	workflow, currentPipeline, repo, err := loadWorkflowContext(_store, workflowID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	if currentPipeline.Status == model.StatusPending {
+		currentPipeline, err = pipeline.UpdateToStatusRunning(_store, *currentPipeline, state.Started)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		pipeline.EmitEvent(plugin.EventPipelineStarted, repo, currentPipeline, "")
+	}
+
+	if _, err := pipeline.UpdateWorkflowStatusToRunning(_store, *workflow, state); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	log.Debug().Int64("workflow", workflowID).Msg("status-api: workflow initialized")
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// handleUpdate updates a step's status within a workflow.
+// Equivalent to RPC.Update() but without agent context.
+func handleUpdate(c *gin.Context) {
+	_store := store.FromContext(c)
+	if _store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "store not available"})
+		return
+	}
+	workflowID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workflow id"})
+		return
+	}
+
+	var state rpc.StepState
+	if err := c.ShouldBindJSON(&state); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	_, currentPipeline, repo, err := loadWorkflowContext(_store, workflowID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	step, err := _store.StepByUUID(state.StepUUID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "step not found"})
+		return
+	}
+
+	if err := pipeline.UpdateStepStatus(c, _store, step, state); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	if state.Exited {
+		pipeline.EmitEvent(plugin.EventStepCompleted, repo, currentPipeline, step.Name)
+	}
+
+	log.Debug().Int64("workflow", workflowID).Str("step", step.Name).Msg("status-api: step updated")
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// handleDone marks a workflow as complete and finalizes the pipeline if all
+// workflows are done. Equivalent to RPC.Done() but without agent/queue context.
+func handleDone(c *gin.Context) {
+	_store := store.FromContext(c)
+	if _store == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "store not available"})
+		return
+	}
+	workflowID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid workflow id"})
+		return
+	}
+
+	var state rpc.WorkflowState
+	if err := c.ShouldBindJSON(&state); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	workflow, currentPipeline, repo, err := loadWorkflowContext(_store, workflowID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+		return
+	}
+
+	if _, err := pipeline.UpdateWorkflowStatusToDone(_store, *workflow, state); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Acknowledge in the queue so the server knows the task is done
+	queue := server.Config.Services.Queue
+	if queue != nil {
+		queueID := strconv.FormatInt(workflowID, 10)
+		if err := queue.Done(c, queueID, model.StatusSuccess); err != nil {
+			log.Warn().Err(err).Int64("workflow", workflowID).Msg("status-api: queue done failed")
+		}
+	}
+
+	// Check if all workflows are done — if so, finalize the pipeline
+	if err := finalizePipelineIfDone(_store, currentPipeline, repo, state.Finished); err != nil {
+		log.Warn().Err(err).Int64("pipeline", currentPipeline.ID).Msg("status-api: finalize failed")
+	}
+
+	log.Debug().Int64("workflow", workflowID).Msg("status-api: workflow done")
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}

--- a/server/plugin/statusapi/handler.go
+++ b/server/plugin/statusapi/handler.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusapi
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Handler implements plugin.StatusHook, providing REST endpoints for
+// external agents to report workflow status back to the Woodpecker server.
+// This replaces the gRPC Init/Update/Done calls for externally-dispatched work.
+type Handler struct {
+	token string
+}
+
+// New creates a Handler with the given bearer token for authentication.
+func New(token string) *Handler {
+	return &Handler{token: token}
+}
+
+func (h *Handler) Name() string { return "status-api" }
+
+// RegisterRoutes adds init/update/done endpoints under the plugin's group.
+// Routes: POST /workflows/:id/init, /workflows/:id/update, /workflows/:id/done
+// Handlers use store.FromContext(c) to access the database.
+func (h *Handler) RegisterRoutes(group *gin.RouterGroup) {
+	group.Use(h.bearerAuth())
+
+	wf := group.Group("/workflows/:id")
+	{
+		wf.POST("/init", handleInit)
+		wf.POST("/update", handleUpdate)
+		wf.POST("/done", handleDone)
+	}
+}
+
+func (h *Handler) Close() error { return nil }
+
+// bearerAuth validates the Authorization header against the configured token.
+func (h *Handler) bearerAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		auth := c.GetHeader("Authorization")
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if token == "" || token == auth || token != h.token {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/server/plugin/statusapi/handler_test.go
+++ b/server/plugin/statusapi/handler_test.go
@@ -1,0 +1,197 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusapi
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	mocks_store "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupRouter(token string) *gin.Engine {
+	r := gin.New()
+	h := New(token)
+	h.RegisterRoutes(r.Group("/api/plugins/status-api"))
+	return r
+}
+
+func setupRouterWithStore(token string, _store store.Store) *gin.Engine {
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		store.ToContext(c, _store)
+		c.Next()
+	})
+	h := New(token)
+	h.RegisterRoutes(r.Group("/api/plugins/status-api"))
+	return r
+}
+
+func TestName(t *testing.T) {
+	h := New("test-token")
+	assert.Equal(t, "status-api", h.Name())
+}
+
+func TestClose(t *testing.T) {
+	h := New("test-token")
+	assert.NoError(t, h.Close())
+}
+
+func TestBearerAuthValid(t *testing.T) {
+	r := setupRouter("secret-token")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/1/init", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer secret-token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	// Auth passes but store is nil in test → 500 (not 401)
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "store not available")
+}
+
+func TestBearerAuthMissing(t *testing.T) {
+	r := setupRouter("secret-token")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/1/init", strings.NewReader("{}"))
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestBearerAuthWrongToken(t *testing.T) {
+	r := setupRouter("secret-token")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/1/init", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestBearerAuthNotBearer(t *testing.T) {
+	r := setupRouter("secret-token")
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/1/init", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestInvalidWorkflowID(t *testing.T) {
+	mockStore := mocks_store.NewMockStore(t)
+	r := setupRouterWithStore("token", mockStore)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/abc/init", strings.NewReader("{}"))
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestInitWorkflowNotFound(t *testing.T) {
+	mockStore := mocks_store.NewMockStore(t)
+	mockStore.On("WorkflowLoad", int64(999)).Return(nil, fmt.Errorf("not found"))
+	r := setupRouterWithStore("token", mockStore)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/999/init",
+		strings.NewReader(`{"started": 1234567890}`))
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestInitSuccess(t *testing.T) {
+	mockStore := mocks_store.NewMockStore(t)
+	workflow := &model.Workflow{ID: 1, PipelineID: 10, State: model.StatusPending}
+	pl := &model.Pipeline{ID: 10, RepoID: 100, Status: model.StatusRunning}
+	repo := &model.Repo{ID: 100, FullName: "org/repo"}
+
+	mockStore.On("WorkflowLoad", int64(1)).Return(workflow, nil)
+	mockStore.On("GetPipeline", int64(10)).Return(pl, nil)
+	mockStore.On("GetRepo", int64(100)).Return(repo, nil)
+	mockStore.On("WorkflowUpdate", mock.AnythingOfType("*model.Workflow")).Return(nil)
+
+	r := setupRouterWithStore("token", mockStore)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/1/init",
+		strings.NewReader(`{"started": 1234567890}`))
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestUpdateStepNotFound(t *testing.T) {
+	mockStore := mocks_store.NewMockStore(t)
+	workflow := &model.Workflow{ID: 1, PipelineID: 10}
+	pl := &model.Pipeline{ID: 10, RepoID: 100, Status: model.StatusRunning}
+	repo := &model.Repo{ID: 100, FullName: "org/repo"}
+
+	mockStore.On("WorkflowLoad", int64(1)).Return(workflow, nil)
+	mockStore.On("GetPipeline", int64(10)).Return(pl, nil)
+	mockStore.On("GetRepo", int64(100)).Return(repo, nil)
+	mockStore.On("StepByUUID", "nonexistent").Return(nil, fmt.Errorf("not found"))
+
+	r := setupRouterWithStore("token", mockStore)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/plugins/status-api/workflows/1/update",
+		strings.NewReader(`{"step_uuid": "nonexistent", "started": 123}`))
+	req.Header.Set("Authorization", "Bearer token")
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRoutesRegistered(t *testing.T) {
+	r := setupRouter("token")
+	routes := r.Routes()
+
+	paths := make(map[string]bool)
+	for _, route := range routes {
+		paths[route.Method+" "+route.Path] = true
+	}
+
+	assert.True(t, paths["POST /api/plugins/status-api/workflows/:id/init"])
+	assert.True(t, paths["POST /api/plugins/status-api/workflows/:id/update"])
+	assert.True(t, paths["POST /api/plugins/status-api/workflows/:id/done"])
+}

--- a/server/plugin/statusapi/helpers.go
+++ b/server/plugin/statusapi/helpers.go
@@ -1,0 +1,65 @@
+// Copyright 2024 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statusapi
+
+import (
+	"fmt"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/pipeline"
+	"go.woodpecker-ci.org/woodpecker/v3/server/plugin"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+)
+
+// loadWorkflowContext loads the workflow, its pipeline, and repo from the store.
+func loadWorkflowContext(_store store.Store, workflowID int64) (*model.Workflow, *model.Pipeline, *model.Repo, error) {
+	workflow, err := _store.WorkflowLoad(workflowID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("workflow %d not found: %w", workflowID, err)
+	}
+
+	pl, err := _store.GetPipeline(workflow.PipelineID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("pipeline %d not found: %w", workflow.PipelineID, err)
+	}
+
+	repo, err := _store.GetRepo(pl.RepoID)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("repo %d not found: %w", pl.RepoID, err)
+	}
+
+	return workflow, pl, repo, nil
+}
+
+// finalizePipelineIfDone checks if all workflows are complete and, if so,
+// updates the pipeline status and emits a completion event.
+func finalizePipelineIfDone(_store store.Store, pl *model.Pipeline, repo *model.Repo, finished int64) error {
+	pl.Workflows, _ = _store.WorkflowGetTree(pl)
+
+	for _, wf := range pl.Workflows {
+		if wf.Running() {
+			return nil // still running
+		}
+	}
+
+	status := pipeline.PipelineStatus(pl.Workflows)
+	updatedPl, err := pipeline.UpdateStatusToDone(_store, *pl, status, finished)
+	if err != nil {
+		return err
+	}
+
+	pipeline.EmitEvent(plugin.EventPipelineCompleted, repo, updatedPl, "")
+	return nil
+}

--- a/server/queue/fifo.go
+++ b/server/queue/fifo.go
@@ -52,6 +52,7 @@ type fifo struct {
 	waitingOnDeps *list.List
 	extension     time.Duration
 	paused        bool
+	dispatchHook  DispatchFunc
 }
 
 // processTimeInterval is the time till the queue rearranges things,
@@ -248,6 +249,14 @@ func (q *fifo) KickAgentWorkers(agentID int64) {
 	}
 }
 
+// SetDispatchHook sets a function called for each pending task before
+// worker assignment. If it returns handled=true, the task moves to running.
+func (q *fifo) SetDispatchHook(fn DispatchFunc) {
+	q.Lock()
+	defer q.Unlock()
+	q.dispatchHook = fn
+}
+
 // helper function that loops through the queue and attempts to
 // match the item to a single subscriber until context got cancel.
 func (q *fifo) process() {
@@ -266,6 +275,25 @@ func (q *fifo) process() {
 
 		q.resubmitExpiredPipelines()
 		q.filterWaiting()
+
+		// External dispatch: offer pending tasks to the hook before agent assignment
+		if q.dispatchHook != nil {
+			for element := q.pending.Front(); element != nil; {
+				task, _ := element.Value.(*model.Task)
+				next := element.Next()
+				if handled, _ := q.dispatchHook(q.ctx, task); handled {
+					q.pending.Remove(element)
+					q.running[task.ID] = &entry{
+						item:     task,
+						done:     make(chan bool),
+						deadline: time.Now().Add(q.extension),
+					}
+					log.Debug().Str("task", task.ID).Msg("queue: task claimed by dispatch hook")
+				}
+				element = next
+			}
+		}
+
 		for pending, worker := q.assignToWorker(); pending != nil && worker != nil; pending, worker = q.assignToWorker() {
 			task, _ := pending.Value.(*model.Task)
 			task.AgentID = worker.agentID

--- a/server/queue/mocks/mock_Queue.go
+++ b/server/queue/mocks/mock_Queue.go
@@ -635,3 +635,8 @@ func (_c *MockQueue_Wait_Call) RunAndReturn(run func(c context.Context, id strin
 	_c.Call.Return(run)
 	return _c
 }
+
+// SetDispatchHook provides a mock function for the type MockQueue.
+func (_mock *MockQueue) SetDispatchHook(fn queue.DispatchFunc) {
+	_mock.Called(fn)
+}

--- a/server/queue/queue.go
+++ b/server/queue/queue.go
@@ -143,7 +143,16 @@ type Queue interface {
 
 	// KickAgentWorkers kicks all workers for a given agent.
 	KickAgentWorkers(agentID int64)
+
+	// SetDispatchHook sets a function called for each pending task before
+	// worker assignment. If it returns handled=true, the task moves directly
+	// to running without being assigned to an agent worker.
+	SetDispatchHook(fn DispatchFunc)
 }
+
+// DispatchFunc is called for each pending task before worker assignment.
+// Return handled=true to claim the task for external dispatch.
+type DispatchFunc func(ctx context.Context, task *model.Task) (handled bool, err error)
 
 // Config holds the configuration for the queue.
 type Config struct {

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -273,5 +273,20 @@ func apiRoutes(e *gin.RouterGroup) {
 				debugger.GET("/pprof/trace", debug.TraceHandler())
 			}
 		}
+
+		// Plugin routes — each StatusHook owns a sub-path under /api/plugins/<name>/
+		registerPluginRoutes(apiBase)
+	}
+}
+
+func registerPluginRoutes(apiBase *gin.RouterGroup) {
+	registry := server.Config.Services.Plugins
+	if registry == nil {
+		return
+	}
+
+	plugins := apiBase.Group("/plugins")
+	for _, hook := range registry.StatusHooks() {
+		hook.RegisterRoutes(plugins.Group("/" + hook.Name()))
 	}
 }


### PR DESCRIPTION
## Summary
- **Status API plugin** (#645): REST endpoints (`/api/plugins/status-api/workflows/:id/{init,update,done}`) for external agents to report workflow status with bearer token auth. Reuses pipeline package functions for status transitions.
- **External Dispatch plugin** (#646): DispatchHook that intercepts pending tasks in the queue before agent assignment, publishes `task.available` events to the event bus for external systems (scaler → WebSocket → agent).
- Adds `DispatchFunc` + `SetDispatchHook` to Queue interface with injection in `fifo.process()`
- Changes `StatusHook.RegisterRoutes` to not require store param (handlers use `store.FromContext`)
- Registers plugin routes under `/api/plugins/<name>/` in router

## Files
| File | Purpose |
|------|---------|
| `server/plugin/statusapi/handler.go` | StatusHook struct, route registration, bearer auth |
| `server/plugin/statusapi/endpoints.go` | init/update/done handlers |
| `server/plugin/statusapi/helpers.go` | Shared context loading, pipeline finalization |
| `server/plugin/statusapi/handler_test.go` | 11 tests — auth, routing, mock store operations |
| `server/plugin/externaldispatch/dispatch.go` | DispatchHook, task.available event publishing |
| `server/plugin/externaldispatch/dispatch_test.go` | 5 tests — event publishing, fallbacks |
| `server/queue/queue.go` | DispatchFunc type, SetDispatchHook on Queue interface |
| `server/queue/fifo.go` | Dispatch hook injection in process() |
| `server/plugin/interfaces.go` | StatusHook signature change, EventTaskAvailable |
| `server/router/api.go` | Plugin route registration |
| `cmd/server/setup_plugins.go` | status-api + external-dispatch wiring |
| `cmd/server/flags.go` | STATUS_API_TOKEN flag |

## Test plan
- [x] 11 statusapi tests — bearer auth, invalid IDs, workflow not found, init success, step not found, route registration
- [x] 5 externaldispatch tests — event publishing, no-bus fallback, multi-task
- [x] All existing queue tests pass (12s suite)
- [x] All existing plugin framework tests pass (registry, eventbus)
- [x] go vet clean on all changed packages
- [ ] Integration: deploy with `WOODPECKER_PLUGINS=status-api,external-dispatch`, verify task interception and status reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)