### PR TITLE
feat: CI pipeline for Woodpecker fork (#651)

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -1,0 +1,24 @@
+when:
+  - event: push
+    branch: main
+
+labels:
+  platform: linux
+  backend: local
+
+steps:
+  - name: build-and-push
+    image: bash
+    commands:
+      - scripts/woodpecker/pts-build.sh
+
+  - name: notify-status
+    image: bash
+    environment:
+      SLACK_WEBHOOK_URL:
+        from_secret: slack_webhook_url
+    commands:
+      - scripts/woodpecker/pts-notify.sh
+    when:
+      - status: [success, failure]
+    depends_on: [build-and-push]

--- a/.woodpecker/pts-ci.yaml
+++ b/.woodpecker/pts-ci.yaml
@@ -1,0 +1,31 @@
+when:
+  - event: push
+    branch:
+      exclude: [main, "merge/*", "sync/*", "release/*"]
+
+labels:
+  platform: linux
+  backend: local
+
+steps:
+  - name: test
+    image: bash
+    commands:
+      - scripts/woodpecker/pts-test.sh
+
+  - name: lint
+    image: bash
+    commands:
+      - scripts/woodpecker/pts-lint.sh
+    depends_on: []
+
+  - name: notify-status
+    image: bash
+    environment:
+      SLACK_WEBHOOK_URL:
+        from_secret: slack_webhook_url
+    commands:
+      - scripts/woodpecker/pts-notify.sh
+    when:
+      - status: [failure]
+    depends_on: [test, lint]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,3 +8,4 @@
 - Add Status API plugin: REST endpoints for external agents to report workflow init/update/done with bearer token auth (#645)
 - Add External Dispatch plugin: intercepts queue task assignment, publishes task.available events for external agent dispatch via WebSocket (#646)
 - Add multi-stage Dockerfile: Node frontend build + Go server build with plugins, Alpine runtime with static-linked CGO for SQLite support (#650)
+- Add CI pipeline: pts-ci (test + lint on feature branches), pts-build (Docker build + push to Artifact Registry on main) (#651)

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REGISTRY="us-central1-docker.pkg.dev/ci-runners-de/ci-images"
+IMAGE="${REGISTRY}/woodpecker-server"
+SHA_SHORT=$(echo "${CI_COMMIT_SHA:-$(git rev-parse HEAD)}" | cut -c1-8)
+VERSION="v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}"
+
+echo "==> Building Docker image: ${IMAGE}:${SHA_SHORT}"
+echo "    Version: ${VERSION}"
+
+# Authenticate to Artifact Registry using agent SA
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet 2>/dev/null || true
+
+docker build \
+  --build-arg "VERSION=${VERSION}" \
+  -t "${IMAGE}:${SHA_SHORT}" \
+  -t "${IMAGE}:latest" \
+  .
+
+echo "==> Pushing to Artifact Registry..."
+docker push "${IMAGE}:${SHA_SHORT}"
+docker push "${IMAGE}:latest"
+
+echo "==> Build complete: ${IMAGE}:${SHA_SHORT} (${VERSION})"

--- a/scripts/woodpecker/pts-lint.sh
+++ b/scripts/woodpecker/pts-lint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Running go vet on Peregrine packages..."
+
+# Our packages only — skip web/, cmd/server/, server/router/ (need frontend build)
+PACKAGES=(
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/...
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/gcppubsub/...
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/statusapi/...
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/externaldispatch/...
+  go.woodpecker-ci.org/woodpecker/v3/server/queue/...
+)
+
+go vet "${PACKAGES[@]}"
+
+echo "==> Lint passed"

--- a/scripts/woodpecker/pts-notify.sh
+++ b/scripts/woodpecker/pts-notify.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${SLACK_WEBHOOK_URL:-}" ]; then
+  echo "SLACK_WEBHOOK_URL not set, skipping notification"
+  exit 0
+fi
+
+REPO="${CI_REPO:-unknown}"
+PIPELINE="${CI_PIPELINE_NUMBER:-0}"
+STATUS="${CI_PIPELINE_STATUS:-unknown}"
+BRANCH="${CI_COMMIT_BRANCH:-unknown}"
+COMMIT_MSG=$(echo "${CI_COMMIT_MESSAGE:-}" | head -1 | cut -c1-80)
+LINK="${CI_PIPELINE_FORGE_URL:-}"
+
+if [ "$STATUS" = "success" ]; then
+  COLOR="#36a64f"
+  EMOJI=":white_check_mark:"
+else
+  COLOR="#dc3545"
+  EMOJI=":x:"
+fi
+
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"attachments\": [{
+      \"color\": \"${COLOR}\",
+      \"text\": \"${EMOJI} *${REPO}* #${PIPELINE} ${STATUS}\\n${BRANCH}: ${COMMIT_MSG}\\n${LINK}\"
+    }]
+  }" || echo "Slack notification failed (non-fatal)"

--- a/scripts/woodpecker/pts-test.sh
+++ b/scripts/woodpecker/pts-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Running tests on Peregrine plugin packages..."
+
+# Our packages only — upstream packages are not our coverage responsibility
+PACKAGES=(
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/...
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/gcppubsub/...
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/statusapi/...
+  go.woodpecker-ci.org/woodpecker/v3/server/plugin/externaldispatch/...
+)
+
+# Skip-CI: if code tree matches main, tests already passed
+HEAD_TREE=$(git rev-parse HEAD^{tree} 2>/dev/null || echo "")
+MAIN_TREE=$(git rev-parse origin/main^{tree} 2>/dev/null || echo "")
+if [ -n "$HEAD_TREE" ] && [ "$HEAD_TREE" = "$MAIN_TREE" ]; then
+  echo "==> Skipping: file content identical to main (already tested)"
+  exit 0
+fi
+
+go test -v -count=1 "${PACKAGES[@]}"
+
+echo "==> Tests passed"


### PR DESCRIPTION
## Summary
- `pts-ci.yaml`: go test + go vet on Peregrine plugin packages (feature branches only)
- `pts-build.yaml`: Docker build + push to Artifact Registry on main merge
- Prefixed with `pts-` to avoid conflicts with upstream pipeline configs
- Skip-CI guard for identical tree objects (promotion merges)
- Slack notifications: failure only for CI, success+failure for builds

## Scripts
| Script | Purpose |
|--------|---------|
| `pts-test.sh` | Tests plugin packages with skip-CI guard |
| `pts-lint.sh` | go vet on plugin + queue packages |
| `pts-build.sh` | Docker build, tag with SHA + latest, push to AR |
| `pts-notify.sh` | Slack webhook notification |

## Next step
- #652: Activate fork repo in Woodpecker + add secrets to trigger first pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)