### PR TITLE
feat: build agent binary from fork source (#658)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ RUN CGO_ENABLED=1 go build \
   -o /build/woodpecker-server \
   ./cmd/server
 
+# Agent does not need CGO (no SQLite)
+RUN CGO_ENABLED=0 go build \
+  -ldflags "-s -w -X go.woodpecker-ci.org/woodpecker/v3/version.Version=${VERSION}" \
+  -o /build/woodpecker-agent \
+  ./cmd/agent
+
 # ── Stage 3: Runtime ─────────────────────────────────────────────
 # Use Alpine instead of scratch — CGO binary needs libc
 FROM docker.io/alpine:3.22

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,3 +9,4 @@
 - Add External Dispatch plugin: intercepts queue task assignment, publishes task.available events for external agent dispatch via WebSocket (#646)
 - Add multi-stage Dockerfile: Node frontend build + Go server build with plugins, Alpine runtime with static-linked CGO for SQLite support (#650)
 - Add CI pipeline: pts-ci (test + lint on feature branches), pts-build (Docker build + push to Artifact Registry on main) (#651)
+- Build agent binary from fork source alongside server — both at gRPC version 15 (#658)


### PR DESCRIPTION
## Summary
- Adds agent build target to Dockerfile alongside server
- Both binaries built from same commit — gRPC version 15 parity
- Agent: CGO_ENABLED=0 (no SQLite), Server: CGO_ENABLED=1 + static
- Fixes root cause of production incident #657

## Next steps
- #659: Update Packer image to use this agent binary
- #660: Coordinated redeployment of server + agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)