### PR TITLE
fix: gcppubsub context canceled on publish (#667)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,3 +10,4 @@
 - Add multi-stage Dockerfile: Node frontend build + Go server build with plugins, Alpine runtime with static-linked CGO for SQLite support (#650)
 - Add CI pipeline: pts-ci (test + lint on feature branches), pts-build (Docker build + push to Artifact Registry on main) (#651)
 - Build agent binary from fork source alongside server — both at gRPC version 15 (#658)
+- Fix gcppubsub publish "context canceled" — use background context for async Pub/Sub delivery (#667)

--- a/server/plugin/gcppubsub/publisher.go
+++ b/server/plugin/gcppubsub/publisher.go
@@ -49,13 +49,13 @@ func New(ctx context.Context, project, topicName string) (*Publisher, error) {
 	topic.PublishSettings.CountThreshold = 100
 	topic.PublishSettings.DelayThreshold = 500 * time.Millisecond
 
-	pub := func(ctx context.Context, data []byte, attrs map[string]string) {
-		result := topic.Publish(ctx, &pubsub.Message{
+	pub := func(_ context.Context, data []byte, attrs map[string]string) {
+		result := topic.Publish(context.Background(), &pubsub.Message{
 			Data:       data,
 			Attributes: attrs,
 		})
 		go func() {
-			if _, err := result.Get(ctx); err != nil {
+			if _, err := result.Get(context.Background()); err != nil {
 				log.Warn().Err(err).Msg("pubsub publish failed")
 			}
 		}()


### PR DESCRIPTION
Pub/Sub publish used event bus context (5s timeout). Batch publisher needs background context for async delivery.