### PR TITLE
fix: queue API 500 on missing agent (#678)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,3 +11,4 @@
 - Add CI pipeline: pts-ci (test + lint on feature branches), pts-build (Docker build + push to Artifact Registry on main) (#651)
 - Build agent binary from fork source alongside server — both at gRPC version 15 (#658)
 - Fix gcppubsub publish "context canceled" — use background context for async Pub/Sub delivery (#667)
+- Fix queue API 500 on missing agent — use placeholder name instead of erroring, prevents cascade cancellation of healthy pipelines (ci-infrastructure#678)

--- a/server/api/hook.go
+++ b/server/api/hook.go
@@ -127,10 +127,13 @@ func processQueueTasks(store store.Store, tasks []*model.Task, agentNameMap map[
 		if task.AgentID != 0 {
 			name, ok := getAgentName(store, agentNameMap, task.AgentID)
 			if !ok {
-				return nil, fmt.Errorf("agent not found for task %s", task.ID)
+				// Agent disappeared (server restart, pruned). Task is still
+				// valid — use placeholder name, don't error. The queue will
+				// reassign it when the deadline expires.
+				taskResponse.AgentName = fmt.Sprintf("agent-%d (disconnected)", task.AgentID)
+			} else {
+				taskResponse.AgentName = name
 			}
-
-			taskResponse.AgentName = name
 		}
 
 		if task.PipelineID != 0 {


### PR DESCRIPTION
One-line fix: placeholder name instead of error when agent disappears. Prevents cascade cancellation.