### PR TITLE
fix: canceled/skipped pipelines update GitHub status to failure

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: canceled/skipped pipelines update GitHub status to failure instead of stuck pending (#159)
 - Add plugin architecture core framework: EventHook, StatusHook, DispatchHook interfaces with registry and channel-based event bus (#642)
 - Add pipeline lifecycle event emission at all lifecycle points: created, pending, started, completed, failed, killed, step.completed (#643)
 - Add GCP Pub/Sub plugin: publishes pipeline events to ci-events topic with sidecar-compatible schema_version "1.0" format (#644)

--- a/server/forge/github/convert.go
+++ b/server/forge/github/convert.go
@@ -36,6 +36,8 @@ const (
 	descFailure  = "the pipeline failed"
 	descBlocked  = "the pipeline requires approval"
 	descDeclined = "the pipeline was rejected"
+	descCanceled = "the pipeline was canceled"
+	descSkipped  = "the pipeline was skipped"
 	descError    = "oops, something went wrong"
 )
 
@@ -49,9 +51,9 @@ const (
 // GitHub commit status.
 func convertStatus(status model.StatusValue) string {
 	switch status {
-	case model.StatusPending, model.StatusRunning, model.StatusBlocked, model.StatusSkipped, model.StatusCanceled:
+	case model.StatusPending, model.StatusRunning, model.StatusBlocked:
 		return statusPending
-	case model.StatusFailure, model.StatusDeclined:
+	case model.StatusFailure, model.StatusDeclined, model.StatusSkipped, model.StatusCanceled:
 		return statusFailure
 	case model.StatusSuccess:
 		return statusSuccess
@@ -74,6 +76,10 @@ func convertDesc(status model.StatusValue) string {
 		return descBlocked
 	case model.StatusDeclined:
 		return descDeclined
+	case model.StatusCanceled:
+		return descCanceled
+	case model.StatusSkipped:
+		return descSkipped
 	default:
 		return descError
 	}


### PR DESCRIPTION
## Summary

One-line fix in `server/forge/github/convert.go` — `StatusSkipped` and `StatusCanceled` were mapped to GitHub `"pending"` state, leaving commit checks stuck forever. Now mapped to `"failure"` with descriptive messages.

## The bug

```go
// BEFORE: canceled pipelines show as "pending" on GitHub forever
case model.StatusPending, model.StatusRunning, model.StatusBlocked, model.StatusSkipped, model.StatusCanceled:
    return statusPending
```

```go
// AFTER: canceled pipelines show as "failure" on GitHub
case model.StatusPending, model.StatusRunning, model.StatusBlocked:
    return statusPending
case model.StatusFailure, model.StatusDeclined, model.StatusSkipped, model.StatusCanceled:
    return statusFailure
```

## Impact

Every repo affected. Any PR whose CI pipeline gets canceled (agent death, rapid pushes, cancel_previous) shows stale "pending" on GitHub, blocking auto-merge.

GitLab, Gitea, and Forgejo already handle this correctly.

## Test plan

- [x] `go test ./server/forge/github/...` passes
- [ ] Deploy, cancel a pipeline, verify GitHub shows failure not pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)