### PR TITLE
feat: auto-route deploy workflows to on-demand agents

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Feat: auto-route deploy workflows to on-demand agents — score-based tier preference (on-demand +20, n2 +15, spot default) with configurable patterns via WOODPECKER_DEPLOY_PATTERNS (ci-infrastructure#798)
+- Fix: merge agent CustomLabels into filter — tier label was never checked during assignment
 - Fix: canceled/skipped pipelines update GitHub status to failure instead of stuck pending (#159)
 - Add plugin architecture core framework: EventHook, StatusHook, DispatchHook interfaces with registry and channel-based event bus (#642)
 - Add pipeline lifecycle event emission at all lifecycle points: created, pending, started, completed, failed, killed, step.completed (#643)

--- a/server/rpc/filter.go
+++ b/server/rpc/filter.go
@@ -24,7 +24,19 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/queue"
 )
 
+// deployTierBoost maps agent tier labels to score boosts for deploy workflows.
+// Higher boost = preferred tier. Agents without a tier label get no boost.
+var deployTierBoost = map[string]int{
+	"ondemand": 20, // non-preemptible, best for deploys
+	"n2":       15, // backup on-demand, second choice
+	// "spot" gets no boost — default fallback
+}
+
 func createFilterFunc(agentFilter rpc.Filter) queue.FilterFn {
+	return createFilterFuncWithDeploy(agentFilter, nil)
+}
+
+func createFilterFuncWithDeploy(agentFilter rpc.Filter, deployPatterns []string) queue.FilterFn {
 	return func(task *model.Task) (bool, int) {
 		// Create a copy of the labels for filtering to avoid modifying the original task
 		labels := maps.Clone(task.Labels)
@@ -69,6 +81,18 @@ func createFilterFunc(agentFilter rpc.Filter) queue.FilterFn {
 				return false, 0
 			}
 		}
+
+		// Deploy auto-routing: boost score for on-demand/n2 agents
+		// when the workflow name matches a deploy pattern.
+		if len(deployPatterns) > 0 {
+			if isDeployWorkflow(task.Name, deployPatterns) {
+				agentTier := agentFilter.Labels["tier"]
+				if boost, ok := deployTierBoost[agentTier]; ok {
+					score += boost
+				}
+			}
+		}
+
 		return true, score
 	}
 }
@@ -80,6 +104,17 @@ func requiredLabelsMissing(taskLabels, agentLabels map[string]string) bool {
 			if !ok || val != value {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// isDeployWorkflow checks if a workflow name matches any deploy pattern.
+func isDeployWorkflow(name string, patterns []string) bool {
+	name = strings.ToLower(name)
+	for _, p := range patterns {
+		if strings.Contains(name, strings.ToLower(p)) {
+			return true
 		}
 	}
 	return false

--- a/server/rpc/filter_test.go
+++ b/server/rpc/filter_test.go
@@ -143,6 +143,67 @@ func TestCreateFilterFunc(t *testing.T) {
 	}
 }
 
+func TestDeployAutoRouting(t *testing.T) {
+	patterns := []string{"deploy", "version-bump", "sync-back"}
+
+	deployTask := &model.Task{
+		Name:   "deploy",
+		Labels: map[string]string{"platform": "linux", "backend": "local"},
+	}
+	ciTask := &model.Task{
+		Name:   "ci",
+		Labels: map[string]string{"platform": "linux", "backend": "local"},
+	}
+
+	ondemandAgent := rpc.Filter{
+		Labels: map[string]string{"platform": "linux", "backend": "local", "tier": "ondemand"},
+	}
+	spotAgent := rpc.Filter{
+		Labels: map[string]string{"platform": "linux", "backend": "local", "tier": "spot"},
+	}
+	n2Agent := rpc.Filter{
+		Labels: map[string]string{"platform": "linux", "backend": "local", "tier": "n2"},
+	}
+
+	// Deploy workflow: on-demand agent gets +20 boost
+	filterOD := createFilterFuncWithDeploy(ondemandAgent, patterns)
+	matched, scoreOD := filterOD(deployTask)
+	assert.True(t, matched)
+
+	filterSpot := createFilterFuncWithDeploy(spotAgent, patterns)
+	matched, scoreSpot := filterSpot(deployTask)
+	assert.True(t, matched)
+
+	assert.Greater(t, scoreOD, scoreSpot, "on-demand should score higher than spot for deploy")
+
+	// N2 agent gets +15 boost — between on-demand and spot
+	filterN2 := createFilterFuncWithDeploy(n2Agent, patterns)
+	matched, scoreN2 := filterN2(deployTask)
+	assert.True(t, matched)
+	assert.Greater(t, scoreN2, scoreSpot, "n2 should score higher than spot for deploy")
+	assert.Greater(t, scoreOD, scoreN2, "on-demand should score higher than n2 for deploy")
+
+	// CI workflow: no boost, all agents score equally
+	_, ciScoreOD := filterOD(ciTask)
+	_, ciScoreSpot := filterSpot(ciTask)
+	assert.Equal(t, ciScoreOD, ciScoreSpot, "CI workflows should not get tier boost")
+}
+
+func TestIsDeployWorkflow(t *testing.T) {
+	patterns := []string{"deploy", "version-bump", "sync-back"}
+
+	assert.True(t, isDeployWorkflow("deploy", patterns))
+	assert.True(t, isDeployWorkflow("deploy-staging", patterns))
+	assert.True(t, isDeployWorkflow("version-bump", patterns))
+	assert.True(t, isDeployWorkflow("sync-back", patterns))
+	assert.True(t, isDeployWorkflow("Deploy", patterns))
+	assert.False(t, isDeployWorkflow("ci", patterns))
+	assert.False(t, isDeployWorkflow("test", patterns))
+	assert.False(t, isDeployWorkflow("lint", patterns))
+	assert.False(t, isDeployWorkflow("", patterns))
+	assert.False(t, isDeployWorkflow("deploy", nil))
+}
+
 func TestMissingRequiredLabels(t *testing.T) {
 	t.Parallel()
 

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -45,12 +45,13 @@ import (
 const updateAgentLastWorkDelay = time.Minute
 
 type RPC struct {
-	queue         queue.Queue
-	pubsub        *pubsub.Publisher
-	logger        logging.Log
-	store         store.Store
-	pipelineTime  *prometheus.GaugeVec
-	pipelineCount *prometheus.CounterVec
+	queue          queue.Queue
+	pubsub         *pubsub.Publisher
+	logger         logging.Log
+	store          store.Store
+	pipelineTime   *prometheus.GaugeVec
+	pipelineCount  *prometheus.CounterVec
+	deployPatterns []string // workflow names that should prefer on-demand agents
 }
 
 // Next blocks until it provides the next workflow to execute.
@@ -78,9 +79,14 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 	// enforce labels from server by overwriting agent labels
 	maps.Copy(agentFilter.Labels, agentServerLabels)
 
+	// merge agent's custom labels (tier, etc.) so filter can score them
+	if agent.CustomLabels != nil {
+		maps.Copy(agentFilter.Labels, agent.CustomLabels)
+	}
+
 	log.Trace().Msgf("Agent %s[%d] tries to pull task with labels: %v", agent.Name, agent.ID, agentFilter.Labels)
 
-	filterFn := createFilterFunc(agentFilter)
+	filterFn := createFilterFuncWithDeploy(agentFilter, s.deployPatterns)
 
 	for {
 		// poll blocks until a task is available or the context is canceled / worker is kicked

--- a/server/rpc/server.go
+++ b/server/rpc/server.go
@@ -17,6 +17,8 @@ package grpc
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
 	prometheus_auto "github.com/prometheus/client_golang/prometheus/promauto"
@@ -49,14 +51,38 @@ func NewWoodpeckerServer(queue queue.Queue, logger logging.Log, pubsub *pubsub.P
 		Help:      "Pipeline count.",
 	}, []string{"repo", "branch", "status", "pipeline"})
 	peer := RPC{
-		store:         store,
-		queue:         queue,
-		pubsub:        pubsub,
-		logger:        logger,
-		pipelineTime:  pipelineTime,
-		pipelineCount: pipelineCount,
+		store:          store,
+		queue:          queue,
+		pubsub:         pubsub,
+		logger:         logger,
+		pipelineTime:   pipelineTime,
+		pipelineCount:  pipelineCount,
+		deployPatterns: loadDeployPatterns(),
 	}
 	return &WoodpeckerServer{peer: peer}
+}
+
+// loadDeployPatterns reads WOODPECKER_DEPLOY_PATTERNS env var.
+// Default: deploy,version-bump,sync-back. Set to empty to disable.
+func loadDeployPatterns() []string {
+	raw := os.Getenv("WOODPECKER_DEPLOY_PATTERNS")
+	if raw == "" {
+		return []string{"deploy", "version-bump", "sync-back"}
+	}
+	if raw == "none" {
+		return nil
+	}
+	var patterns []string
+	for _, p := range strings.Split(raw, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			patterns = append(patterns, p)
+		}
+	}
+	if len(patterns) > 0 {
+		log.Info().Msgf("Deploy auto-routing patterns: %v", patterns)
+	}
+	return patterns
 }
 
 // Version returns the server- & grpc-version.


### PR DESCRIPTION
## Summary

Deploy workflows automatically prefer on-demand agents over spot, without per-repo YAML changes. Score-based tier boost:

- `tier=ondemand`: +20 points
- `tier=n2`: +15 points
- `tier=spot`: no boost (default fallback)

Workflow names matched against `WOODPECKER_DEPLOY_PATTERNS` env var (default: `deploy,version-bump,sync-back`). Set to `none` to disable.

Also fixes: `agent.CustomLabels` were never merged into the filter — the `tier` label from agent config had no effect on task assignment.

## Files changed

- `server/rpc/filter.go` — `createFilterFuncWithDeploy`, `isDeployWorkflow`, tier boost scoring
- `server/rpc/rpc.go` — merge CustomLabels into agent filter, pass deploy patterns
- `server/rpc/server.go` — `loadDeployPatterns` from env var
- `server/rpc/filter_test.go` — deploy routing + pattern matching tests

## Test plan

- [x] `TestDeployAutoRouting` — on-demand > n2 > spot for deploy, equal for CI
- [x] `TestIsDeployWorkflow` — pattern matching
- [x] All existing filter tests pass
- [ ] Deploy, trigger deploy pipeline, verify on-demand agent picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)