### PR TITLE
fix: TaskTimeout 60s → 15s for faster orphan requeue

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: TaskTimeout reduced from 60s to 15s — orphaned tasks requeue 4x faster after agent death (ci-infrastructure#774)
 - Feat: auto-route deploy workflows to on-demand agents — score-based tier preference (on-demand +20, n2 +15, spot default) with configurable patterns via WOODPECKER_DEPLOY_PATTERNS (ci-infrastructure#798)
 - Fix: merge agent CustomLabels into filter — tier label was never checked during assignment
 - Fix: canceled/skipped pipelines update GitHub status to failure instead of stuck pending (#159)

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -38,4 +38,6 @@ var TrustedClonePlugins = []string{
 }
 
 // TaskTimeout is the time till a running task is counted as dead.
-var TaskTimeout = time.Minute
+// Reduced from 60s to 15s for faster orphan requeue after agent death.
+// Extension interval = TaskTimeout/3 = 5s (was 20s).
+var TaskTimeout = 15 * time.Second


### PR DESCRIPTION
One-line change: orphaned tasks requeue in 15s instead of 60s. Fixes ci-infrastructure#774

🤖 Generated with [Claude Code](https://claude.com/claude-code)