### PR TITLE
fix: deploy hold window — spot agents wait 30s for on-demand to boot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: deploy hold window — spot agents wait 30s for on-demand agents to boot before accepting deploy jobs
 - Feat: CI + auto-deploy pipeline — build on merge to main, push to AR, deploy to d3ci42 (ci-infrastructure#648)
 - Fix: TaskTimeout reduced from 60s to 15s — orphaned tasks requeue 4x faster after agent death (ci-infrastructure#774)
 - Feat: auto-route deploy workflows to on-demand agents — score-based tier preference (on-demand +20, n2 +15, spot default) with configurable patterns via WOODPECKER_DEPLOY_PATTERNS (ci-infrastructure#798)

--- a/server/rpc/filter.go
+++ b/server/rpc/filter.go
@@ -17,11 +17,24 @@ package grpc
 import (
 	"maps"
 	"strings"
+	"sync"
+	"time"
 
 	pipelineConsts "go.woodpecker-ci.org/woodpecker/v3/pipeline"
 	"go.woodpecker-ci.org/woodpecker/v3/rpc"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/queue"
+)
+
+// deployHoldWindow is how long spot agents wait before accepting deploy tasks,
+// giving on-demand agents time to boot and claim the job.
+const deployHoldWindow = 30 * time.Second
+
+// deployFirstSeen tracks when a deploy task was first evaluated.
+// After deployHoldWindow, spot agents are allowed to take it.
+var (
+	deployFirstSeen   = make(map[string]time.Time)
+	deployFirstSeenMu sync.Mutex
 )
 
 // deployTierBoost maps agent tier labels to score boosts for deploy workflows.
@@ -82,14 +95,31 @@ func createFilterFuncWithDeploy(agentFilter rpc.Filter, deployPatterns []string)
 			}
 		}
 
-		// Deploy auto-routing: boost score for on-demand/n2 agents
-		// when the workflow name matches a deploy pattern.
-		if len(deployPatterns) > 0 {
-			if isDeployWorkflow(task.Name, deployPatterns) {
-				agentTier := agentFilter.Labels["tier"]
-				if boost, ok := deployTierBoost[agentTier]; ok {
-					score += boost
+		// Deploy auto-routing: boost on-demand/n2 agents and hold
+		// deploy tasks from spot agents for deployHoldWindow seconds.
+		if len(deployPatterns) > 0 && isDeployWorkflow(task.Name, deployPatterns) {
+			agentTier := agentFilter.Labels["tier"]
+
+			// Boost on-demand/n2 agents
+			if boost, ok := deployTierBoost[agentTier]; ok {
+				score += boost
+			}
+
+			// Hold window: spot agents skip deploy tasks for 30s
+			// to give on-demand agents time to boot and claim them.
+			if agentTier == "spot" || agentTier == "" {
+				deployFirstSeenMu.Lock()
+				firstSeen, exists := deployFirstSeen[task.ID]
+				if !exists {
+					deployFirstSeen[task.ID] = time.Now()
+					firstSeen = time.Now()
 				}
+				deployFirstSeenMu.Unlock()
+
+				if time.Since(firstSeen) < deployHoldWindow {
+					return false, 0 // reject — waiting for on-demand agent
+				}
+				// Hold expired — let spot take it as fallback
 			}
 		}
 

--- a/server/rpc/filter_test.go
+++ b/server/rpc/filter_test.go
@@ -16,6 +16,7 @@ package grpc
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -147,6 +148,7 @@ func TestDeployAutoRouting(t *testing.T) {
 	patterns := []string{"deploy", "version-bump", "sync-back"}
 
 	deployTask := &model.Task{
+		ID:     "score-test-deploy",
 		Name:   "deploy",
 		Labels: map[string]string{"platform": "linux", "backend": "local"},
 	}
@@ -154,6 +156,11 @@ func TestDeployAutoRouting(t *testing.T) {
 		Name:   "ci",
 		Labels: map[string]string{"platform": "linux", "backend": "local"},
 	}
+
+	// Pre-expire the hold window for scoring tests
+	deployFirstSeenMu.Lock()
+	deployFirstSeen["score-test-deploy"] = time.Now().Add(-deployHoldWindow - time.Second)
+	deployFirstSeenMu.Unlock()
 
 	ondemandAgent := rpc.Filter{
 		Labels: map[string]string{"platform": "linux", "backend": "local", "tier": "ondemand"},
@@ -187,6 +194,27 @@ func TestDeployAutoRouting(t *testing.T) {
 	_, ciScoreOD := filterOD(ciTask)
 	_, ciScoreSpot := filterSpot(ciTask)
 	assert.Equal(t, ciScoreOD, ciScoreSpot, "CI workflows should not get tier boost")
+
+	// Deploy hold window: spot agents reject during hold period
+	holdTask := &model.Task{
+		ID:     "hold-test-task",
+		Name:   "deploy",
+		Labels: map[string]string{"platform": "linux", "backend": "local"},
+	}
+
+	// Clear any prior state
+	deployFirstSeenMu.Lock()
+	delete(deployFirstSeen, "hold-test-task")
+	deployFirstSeenMu.Unlock()
+
+	filterSpotHold := createFilterFuncWithDeploy(spotAgent, patterns)
+	matchedHold, _ := filterSpotHold(holdTask)
+	assert.False(t, matchedHold, "spot should reject deploy task during hold window")
+
+	// On-demand should still accept during hold
+	filterODHold := createFilterFuncWithDeploy(ondemandAgent, patterns)
+	matchedODHold, _ := filterODHold(holdTask)
+	assert.True(t, matchedODHold, "on-demand should accept deploy task during hold window")
 }
 
 func TestIsDeployWorkflow(t *testing.T) {


### PR DESCRIPTION
## Problem

Deploy jobs land on spot agents because they poll before the on-demand VM boots. The scoring preference from PR #11 only helps when both agent types are polling simultaneously.

## Fix

Spot agents reject deploy tasks for 30 seconds after first seen. This gives on-demand VMs time to boot (~60-90s, but the scaler pre-boots on demand detection). After 30s, spot takes it as fallback — deploys never hang.

## How it works

1. Deploy task enters queue
2. Spot agent polls → filter sees it's a deploy + agent is spot → rejects for 30s
3. On-demand VM boots, registers, polls → filter sees on-demand → accepts immediately
4. If no on-demand after 30s → spot gets it (better than hanging)

## Test plan

- [x] `TestDeployAutoRouting` — spot rejected during hold, on-demand accepted
- [x] All existing tests pass
- [ ] Merge → CI builds + deploys automatically (tests #648 pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)