### PR TITLE
fix: workflow independence + TaskTimeout to 5min

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix: workflow independence — Cancel preserves independent workflows (depends_on: []) when superseded by new push, preventing deploy kills on healthy agents (ci-infrastructure#822)
+- Fix: TaskTimeout increased to 5 minutes — safety net only, WebSocket hub handles orphan detection at 20s (ci-infrastructure#162)
 - Fix: deploy hold window — spot agents wait 30s for on-demand agents to boot before accepting deploy jobs
 - Feat: CI + auto-deploy pipeline — build on merge to main, push to AR, deploy to d3ci42 (ci-infrastructure#648)
 - Revert: TaskTimeout back to 60s — 15s caused task expiry under CPU load — orphaned tasks requeue 4x faster after agent death (ci-infrastructure#774)

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -495,7 +495,7 @@ func CancelPipeline(c *gin.Context) {
 
 	if err := pipeline.Cancel(c, _forge, _store, repo, user, pl, &model.CancelInfo{
 		CanceledByUser: user.Login,
-	}); err != nil {
+	}, false); err != nil {
 		handlePipelineErr(c, err)
 	} else {
 		c.Status(http.StatusNoContent)

--- a/server/pipeline/cancel.go
+++ b/server/pipeline/cancel.go
@@ -30,20 +30,33 @@ import (
 )
 
 // Cancel the pipeline and returns the status.
-func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *model.Repo, user *model.User, pipeline *model.Pipeline, cancelInfo *model.CancelInfo) error {
+// When preserveIndependent is true, workflows with no queue dependencies (depends_on: [])
+// are left running — used by cancelPreviousPipelines to avoid killing deploy workflows
+// on healthy agents when a new CI push supersedes a previous one (#822).
+func Cancel(ctx context.Context, _forge forge.Forge, _store store.Store, repo *model.Repo, user *model.User, pipeline *model.Pipeline, cancelInfo *model.CancelInfo, preserveIndependent bool) error {
 	if pipeline.Status != model.StatusRunning && pipeline.Status != model.StatusPending && pipeline.Status != model.StatusBlocked {
 		return &ErrBadRequest{Msg: "Cannot cancel a non-running or non-pending or non-blocked pipeline"}
 	}
 
-	workflows, err := store.WorkflowGetTree(pipeline)
+	workflows, err := _store.WorkflowGetTree(pipeline)
 	if err != nil {
 		return &ErrNotFound{Msg: err.Error()}
+	}
+
+	// Build set of independent workflow IDs (no queue dependencies)
+	independentIDs := make(map[int64]bool)
+	if preserveIndependent {
+		independentIDs = findIndependentWorkflows(_store, pipeline.ID)
 	}
 
 	// First cancel/evict workflows in the queue in one go
 	var workflowsToCancel []string
 	for _, w := range workflows {
 		if w.State == model.StatusRunning || w.State == model.StatusPending {
+			if independentIDs[w.ID] {
+				log.Info().Msgf("cancel: preserving independent workflow %d (%s) (#822)", w.ID, w.Name)
+				continue
+			}
 			workflowsToCancel = append(workflowsToCancel, fmt.Sprint(w.ID))
 		}
 	}
@@ -54,13 +67,21 @@ func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *mo
 		}
 	}
 
+	// Check if any workflows are still running (preserved independent ones)
+	hasPreservedRunning := false
 	hasPendingOnly := true
 
 	// Then update the DB status for pending pipelines
 	// Running ones will be set when the agents stop on the cancel signal
 	for _, workflow := range workflows {
+		if independentIDs[workflow.ID] {
+			if workflow.State == model.StatusRunning || workflow.State == model.StatusPending {
+				hasPreservedRunning = true
+			}
+			continue
+		}
 		if workflow.State == model.StatusPending {
-			if _, err = UpdateWorkflowToStatusSkipped(store, *workflow); err != nil {
+			if _, err = UpdateWorkflowToStatusSkipped(_store, *workflow); err != nil {
 				log.Error().Err(err).Msgf("cannot update workflow with id %d state", workflow.ID)
 			}
 		} else {
@@ -68,18 +89,25 @@ func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *mo
 		}
 		for _, step := range workflow.Children {
 			if step.State == model.StatusPending {
-				if _, err = UpdateStepToStatusSkipped(store, *step, 0, model.StatusCanceled); err != nil {
+				if _, err = UpdateStepToStatusSkipped(_store, *step, 0, model.StatusCanceled); err != nil {
 					log.Error().Err(err).Msgf("cannot update workflow with id %d state", workflow.ID)
 				}
 			}
 		}
 	}
 
+	// If independent workflows are still running, don't kill the pipeline — let them finish.
+	// Pipeline status will be computed when all workflows complete (rpc.Done).
+	if hasPreservedRunning {
+		log.Info().Msgf("cancel: pipeline %d has preserved independent workflows — staying running (#822)", pipeline.ID)
+		return nil
+	}
+
 	plState := model.StatusKilled
 	if hasPendingOnly {
 		plState = model.StatusCanceled
 	}
-	killedPipeline, err := UpdateToStatusKilled(store, *pipeline, cancelInfo, plState)
+	killedPipeline, err := UpdateToStatusKilled(_store, *pipeline, cancelInfo, plState)
 	if err != nil {
 		log.Error().Err(err).Msgf("UpdateToStatusKilled: %v", pipeline)
 		return err
@@ -88,12 +116,34 @@ func Cancel(ctx context.Context, _forge forge.Forge, store store.Store, repo *mo
 	EmitEvent(plugin.EventPipelineKilled, repo, killedPipeline, "")
 	updatePipelineStatus(ctx, _forge, killedPipeline, repo, user)
 
-	if killedPipeline.Workflows, err = store.WorkflowGetTree(killedPipeline); err != nil {
+	if killedPipeline.Workflows, err = _store.WorkflowGetTree(killedPipeline); err != nil {
 		return err
 	}
 	publishToTopic(killedPipeline, repo)
 
 	return nil
+}
+
+// findIndependentWorkflows returns workflow IDs that have no queue dependencies.
+// These are workflows with depends_on: [] in the pipeline config — they should
+// not be canceled when a pipeline is superseded by a new push.
+func findIndependentWorkflows(_store store.Store, pipelineID int64) map[int64]bool {
+	result := make(map[int64]bool)
+	tasks, err := _store.TaskList()
+	if err != nil {
+		log.Error().Err(err).Msg("findIndependentWorkflows: cannot list tasks")
+		return result
+	}
+	for _, task := range tasks {
+		if task.PipelineID == pipelineID && len(task.Dependencies) == 0 {
+			// Task ID is the string form of workflow ID
+			var wfID int64
+			if _, err := fmt.Sscan(task.ID, &wfID); err == nil {
+				result[wfID] = true
+			}
+		}
+	}
+	return result
 }
 
 func cancelPreviousPipelines(
@@ -145,7 +195,7 @@ func cancelPreviousPipelines(
 
 		if err = Cancel(ctx, _forge, _store, repo, user, active, &model.CancelInfo{
 			SupersededBy: pipeline.Number,
-		}); err != nil {
+		}, true); err != nil {
 			log.Error().
 				Err(err).
 				Str("ref", active.Ref).

--- a/server/pipeline/cancel_test.go
+++ b/server/pipeline/cancel_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestFindIndependentWorkflows(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identifies workflows with no dependencies", func(t *testing.T) {
+		t.Parallel()
+		s := mocks.NewMockStore(t)
+		s.On("TaskList").Return([]*model.Task{
+			{ID: "100", PipelineID: 1, Dependencies: []string{"99"}},
+			{ID: "101", PipelineID: 1, Dependencies: []string{}},
+			{ID: "102", PipelineID: 1, Dependencies: nil},
+		}, nil)
+
+		result := findIndependentWorkflows(s, 1)
+		assert.False(t, result[100], "workflow with deps should not be independent")
+		assert.True(t, result[101], "workflow with empty deps should be independent")
+		assert.True(t, result[102], "workflow with nil deps should be independent")
+	})
+
+	t.Run("filters by pipeline ID", func(t *testing.T) {
+		t.Parallel()
+		s := mocks.NewMockStore(t)
+		s.On("TaskList").Return([]*model.Task{
+			{ID: "100", PipelineID: 1, Dependencies: nil},
+			{ID: "200", PipelineID: 2, Dependencies: nil},
+		}, nil)
+
+		result := findIndependentWorkflows(s, 1)
+		assert.True(t, result[100])
+		assert.False(t, result[200], "task from different pipeline should be excluded")
+	})
+
+	t.Run("returns empty map on store error", func(t *testing.T) {
+		t.Parallel()
+		s := mocks.NewMockStore(t)
+		s.On("TaskList").Return(nil, assert.AnError)
+
+		result := findIndependentWorkflows(s, 1)
+		assert.Empty(t, result)
+	})
+}

--- a/server/pipeline/step_status.go
+++ b/server/pipeline/step_status.go
@@ -129,7 +129,7 @@ func cancelPipelineFromStep(ctx context.Context, store store.Store, step *model.
 	}
 	return Cancel(ctx, _forge, store, repo, repoUser, pipeline, &model.CancelInfo{
 		CanceledByStep: step.Name,
-	})
+	}, false)
 }
 
 func UpdateStepToStatusSkipped(store store.Store, step model.Step, finished int64, status model.StatusValue) (*model.Step, error) {

--- a/shared/constant/constant.go
+++ b/shared/constant/constant.go
@@ -37,7 +37,8 @@ var TrustedClonePlugins = []string{
 	"quay.io/woodpeckerci/plugin-git",
 }
 
-// TaskTimeout is the time till a running task is counted as dead.
-// Reduced from 60s to 15s for faster orphan requeue after agent death.
-// Kept at 60s — 15s was too aggressive, caused task expiry under CPU load.
-var TaskTimeout = 60 * time.Second
+// TaskTimeout is the queue lease duration — how long before an unextended task is requeued.
+// The WebSocket heartbeat hub (20s orphan detection) is the primary mechanism for detecting
+// dead agents. TaskTimeout is a safety net only — set high to avoid false expiry under CPU load.
+// History: 60s (original) → 15s (too aggressive, tasks expired under load) → 5min (#162).
+var TaskTimeout = 5 * time.Minute


### PR DESCRIPTION
## Summary
- Cancel() preserves independent workflows (`depends_on: []`) when pipeline is superseded — deploy on healthy on-demand agents no longer killed when CI is canceled on spot (#822)
- TaskTimeout increased from 60s to 5min — WebSocket hub handles orphan detection at 20s, this is a safety net only (#162)
- Addresses production incident #825 (ghost pipelines kept VMs alive 4+ days)

## Test plan
- [x] `findIndependentWorkflows` unit tests (3 cases: deps/no-deps/store-error)
- [x] All server tests pass (`go test ./server/...`)
- [ ] Build Docker image `--platform linux/amd64`
- [ ] Deploy to d3ci42, verify deploy workflows survive CI cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)