### PR TITLE
fix: pipeline list API supports multiple status filter values (#881)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: pipeline list API supports multiple status values — `?status=running&status=pending` now returns both. Single status query returned only the first value, causing scaler to miss pending pipelines (ci-infrastructure#881)
 - Feat: Full WebSocket agent transport — replaces gRPC for agent↔server communication. All 11 RPC methods (Next, Wait, Init, Done, Update, Extend, Log, RegisterAgent, UnregisterAgent, ReportHealth, Version) over single bidirectional WebSocket at /ws/agent. Fixes deploy workflows killed by gRPC disconnect (#3496, #3497, #3360, #857). Feature flag: WOODPECKER_AGENT_TRANSPORT=ws (default grpc for upstream compat) (ci-infrastructure#474)
 - Fix: shared RPC peer between gRPC and WS transports — duplicate prometheus metric registration caused panic on startup
 - Fix: WS agent registration creates agent via store directly — RPC.RegisterAgent requires pre-existing agent_id from gRPC auth flow

--- a/server/api/pipeline.go
+++ b/server/api/pipeline.go
@@ -143,13 +143,19 @@ func GetPipelines(c *gin.Context) {
 		filter.Events = wel
 	}
 
-	if status := c.Query("status"); status != "" {
-		ps := model.StatusValue(status)
-		if err := ps.Validate(); err != nil {
-			_ = c.AbortWithError(http.StatusBadRequest, err)
-			return
+	if statuses := c.QueryArray("status"); len(statuses) > 0 {
+		for _, s := range statuses {
+			ps := model.StatusValue(s)
+			if err := ps.Validate(); err != nil {
+				_ = c.AbortWithError(http.StatusBadRequest, err)
+				return
+			}
+			filter.Statuses = append(filter.Statuses, ps)
 		}
-		filter.Status = ps
+		// Backward compat: also set single Status for queries with one value
+		if len(filter.Statuses) == 1 {
+			filter.Status = filter.Statuses[0]
+		}
 	}
 
 	if before := c.Query("before"); before != "" {

--- a/server/model/pipeline.go
+++ b/server/model/pipeline.go
@@ -69,7 +69,8 @@ type PipelineFilter struct {
 	Branch      string
 	Events      []WebhookEvent
 	RefContains string
-	Status      StatusValue
+	Status      StatusValue   // single status filter (backward compat)
+	Statuses    []StatusValue // multiple status filter (#881)
 }
 
 // IsMultiPipeline checks if step list contain more than one parent step.

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -83,7 +83,9 @@ func (s storage) GetPipelineList(repo *model.Repo, p *model.ListOptions, f *mode
 			cond = cond.And(builder.Eq{"branch": f.Branch})
 		}
 
-		if f.Status != "" {
+		if len(f.Statuses) > 0 {
+			cond = cond.And(builder.In("status", f.Statuses))
+		} else if f.Status != "" {
 			cond = cond.And(builder.Eq{"status": f.Status})
 		}
 


### PR DESCRIPTION
c.Query only returned first status value. Pending pipelines invisible to scaler. Changed to c.QueryArray + builder.In().