### PR TITLE
fix: queue cleanup on cancel + startup reconciliation (#891)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: cancel pipeline also calls queue.Done() for running workflows — prevents ghost tasks when agent is dead and can't call rpc.Done() (ci-infrastructure#891)
 - Fix: pipeline list API supports multiple status values — `?status=running&status=pending` now returns both. Single status query returned only the first value, causing scaler to miss pending pipelines (ci-infrastructure#881)
 - Feat: Full WebSocket agent transport — replaces gRPC for agent↔server communication. All 11 RPC methods (Next, Wait, Init, Done, Update, Extend, Log, RegisterAgent, UnregisterAgent, ReportHealth, Version) over single bidirectional WebSocket at /ws/agent. Fixes deploy workflows killed by gRPC disconnect (#3496, #3497, #3360, #857). Feature flag: WOODPECKER_AGENT_TRANSPORT=ws (default grpc for upstream compat) (ci-infrastructure#474)
 - Fix: shared RPC peer between gRPC and WS transports — duplicate prometheus metric registration caused panic on startup

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: cancel pipeline also calls queue.Done() for running workflows — prevents ghost tasks when agent is dead and can't call rpc.Done() (ci-infrastructure#891)
+- Fix: startup reconciliation kills orphaned "running" pipelines — after server restart, pipelines stuck in running state with no queue task are marked as killed (ci-infrastructure#891)
 - Fix: pipeline list API supports multiple status values — `?status=running&status=pending` now returns both. Single status query returned only the first value, causing scaler to miss pending pipelines (ci-infrastructure#881)
 - Feat: Full WebSocket agent transport — replaces gRPC for agent↔server communication. All 11 RPC methods (Next, Wait, Init, Done, Update, Extend, Log, RegisterAgent, UnregisterAgent, ReportHealth, Version) over single bidirectional WebSocket at /ws/agent. Fixes deploy workflows killed by gRPC disconnect (#3496, #3497, #3360, #857). Feature flag: WOODPECKER_AGENT_TRANSPORT=ws (default grpc for upstream compat) (ci-infrastructure#474)
 - Fix: shared RPC peer between gRPC and WS transports — duplicate prometheus metric registration caused panic on startup

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -34,6 +34,7 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/forge/setup"
 	"go.woodpecker-ci.org/woodpecker/v3/server/logging"
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/pipeline"
 	"go.woodpecker-ci.org/woodpecker/v3/server/pubsub"
 	"go.woodpecker-ci.org/woodpecker/v3/server/queue"
 	woodpeckerGrpc "go.woodpecker-ci.org/woodpecker/v3/server/rpc"
@@ -174,6 +175,11 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	if err != nil {
 		return fmt.Errorf("could not setup log store: %w", err)
 	}
+
+	// #891: Reconcile orphaned "running" pipelines after restart.
+	// The in-memory queue is lost on restart — pipelines that were running
+	// have no queue task and will never complete. Mark them as killed.
+	pipeline.ReconcileOrphaned(s)
 
 	// WebSocket agent transport (#474) — shares business logic with gRPC
 	server.Config.Services.WSAgentRPC = woodpeckerGrpc.NewRPC(

--- a/server/pipeline/cancel.go
+++ b/server/pipeline/cancel.go
@@ -68,6 +68,18 @@ func Cancel(ctx context.Context, _forge forge.Forge, _store store.Store, repo *m
 		}
 	}
 
+	// #891: Also call Done() for running workflows. ErrorAtOnce removes tasks
+	// from pending/waiting, but running tasks assigned to dead agents stay in
+	// the queue's running map until the agent calls rpc.Done() — which never
+	// happens if the agent crashed. Done() ensures cleanup regardless.
+	for _, w := range workflows {
+		if w.State == model.StatusRunning && !independentIDs[w.ID] {
+			if err := server.Config.Services.Queue.Done(ctx, fmt.Sprint(w.ID), model.StatusKilled); err != nil {
+				log.Debug().Err(err).Msgf("queue.Done for running workflow %d (may already be removed)", w.ID)
+			}
+		}
+	}
+
 	// Check if any workflows are still running (preserved independent ones)
 	hasPreservedRunning := false
 	hasPendingOnly := true

--- a/server/pipeline/cancel_test.go
+++ b/server/pipeline/cancel_test.go
@@ -301,6 +301,10 @@ func TestCancel_NoPreserve(t *testing.T) {
 		return len(ids) == 2
 	}), mock.Anything).Return(nil)
 
+	// #891: Done() called for both running workflows to clean up queue
+	mockQueue.On("Done", mock.Anything, "30", model.StatusKilled).Return(nil)
+	mockQueue.On("Done", mock.Anything, "31", model.StatusKilled).Return(nil)
+
 	// Pipeline killed (not pending-only since both are running)
 	mockStore.On("UpdatePipeline", mock.MatchedBy(func(p *model.Pipeline) bool {
 		return p.ID == 3 && p.Status == model.StatusKilled
@@ -314,6 +318,57 @@ func TestCancel_NoPreserve(t *testing.T) {
 
 	assert.NoError(t, err)
 	mockStore.AssertCalled(t, "UpdatePipeline", mock.Anything)
+}
+
+// TestCancel_RunningWorkflow_QueueDone ensures that canceling a pipeline with
+// running workflows calls queue.Done() in addition to ErrorAtOnce().
+// Without this, ghost tasks stay in the queue's running map when the agent is
+// dead — ErrorAtOnce only removes pending/waiting tasks, not running ones that
+// the agent should have cleaned up via rpc.Done() (#891).
+func TestCancel_RunningWorkflow_QueueDone(t *testing.T) {
+	mockStore, mockQueue := setupCancelTest(t)
+
+	pipeline := &model.Pipeline{
+		ID:     5,
+		Number: 500,
+		Status: model.StatusRunning,
+	}
+	repo := &model.Repo{ID: 1, FullName: "org/scanner"}
+	user := &model.User{ID: 1}
+
+	workflows := []*model.Workflow{
+		{
+			ID:        50,
+			Name:      "ci",
+			State:     model.StatusRunning,
+			DependsOn: []string{},
+			Children:  []*model.Step{},
+		},
+	}
+
+	mockStore.On("WorkflowGetTree", pipeline).Return(workflows, nil)
+
+	// ErrorAtOnce called for the running workflow
+	mockQueue.On("ErrorAtOnce", mock.Anything, []string{"50"}, mock.Anything).Return(nil)
+
+	// #891: queue.Done() must ALSO be called for running workflows to ensure
+	// the task is removed from the queue's running map even if the agent is dead
+	mockQueue.On("Done", mock.Anything, "50", model.StatusKilled).Return(nil)
+
+	// Pipeline killed
+	mockStore.On("UpdatePipeline", mock.MatchedBy(func(p *model.Pipeline) bool {
+		return p.ID == 5 && p.Status == model.StatusKilled
+	})).Return(nil)
+
+	mockStore.On("WorkflowGetTree", mock.AnythingOfType("*model.Pipeline")).Return(workflows, nil)
+
+	err := Cancel(context.Background(), nil, mockStore, repo, user, pipeline, &model.CancelInfo{
+		CanceledByUser: "system",
+	}, false)
+
+	assert.NoError(t, err)
+	// Verify Done was called — this is the critical assertion
+	mockQueue.AssertCalled(t, "Done", mock.Anything, "50", model.StatusKilled)
 }
 
 // TestCancel_RejectsNonRunningPipeline verifies guard clause.

--- a/server/pipeline/reconcile.go
+++ b/server/pipeline/reconcile.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"github.com/rs/zerolog/log"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+)
+
+// ReconcileOrphaned finds pipelines stuck in "running" or "pending" state
+// with no corresponding queue task and marks them as killed. This handles
+// pipelines orphaned by server restarts — the in-memory queue is lost but
+// the DB still shows them as running (#891).
+func ReconcileOrphaned(_store store.Store) int {
+	repos, err := _store.RepoListAll(true, &model.ListOptions{Page: 1, PerPage: 200})
+	if err != nil {
+		log.Error().Err(err).Msg("reconcile: failed to list repos")
+		return 0
+	}
+
+	reconciled := 0
+	for _, repo := range repos {
+		pipelines, err := _store.GetActivePipelineList(repo)
+		if err != nil {
+			continue
+		}
+		for _, pl := range pipelines {
+			if pl.Status != model.StatusRunning {
+				continue
+			}
+			// Pipeline is "running" in DB — mark as killed since queue is empty after restart
+			log.Info().Msgf("reconcile: killing orphaned pipeline %s#%d (was running, no queue task after restart)",
+				repo.FullName, pl.Number)
+
+			pl.Status = model.StatusKilled
+			if err := _store.UpdatePipeline(pl); err != nil {
+				log.Error().Err(err).Msgf("reconcile: failed to update pipeline %d", pl.ID)
+				continue
+			}
+
+			// Also mark running workflows as killed
+			workflows, err := _store.WorkflowGetTree(pl)
+			if err != nil {
+				continue
+			}
+			for _, w := range workflows {
+				if w.State == model.StatusRunning {
+					w.State = model.StatusKilled
+					if err := _store.WorkflowUpdate(w); err != nil {
+						log.Error().Err(err).Msgf("reconcile: failed to update workflow %d", w.ID)
+					}
+				}
+			}
+			reconciled++
+		}
+	}
+
+	if reconciled > 0 {
+		log.Info().Msgf("reconcile: killed %d orphaned running pipelines", reconciled)
+	}
+	return reconciled
+}

--- a/server/pipeline/reconcile_test.go
+++ b/server/pipeline/reconcile_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestReconcileOrphaned_KillsRunningPipelines(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+
+	repos := []*model.Repo{
+		{ID: 1, FullName: "org/scanner"},
+	}
+	mockStore.On("RepoListAll", true, mock.Anything).Return(repos, nil)
+
+	// Scanner has a "running" pipeline orphaned from before restart
+	pipelines := []*model.Pipeline{
+		{ID: 100, Number: 1020, Status: model.StatusRunning, RepoID: 1},
+	}
+	mockStore.On("GetActivePipelineList", repos[0]).Return(pipelines, nil)
+
+	// Pipeline should be updated to killed
+	mockStore.On("UpdatePipeline", mock.MatchedBy(func(p *model.Pipeline) bool {
+		return p.ID == 100 && p.Status == model.StatusKilled
+	})).Return(nil)
+
+	// Workflow tree for the pipeline
+	workflows := []*model.Workflow{
+		{ID: 50, State: model.StatusRunning, Name: "ci"},
+	}
+	mockStore.On("WorkflowGetTree", pipelines[0]).Return(workflows, nil)
+
+	// Workflow should be updated to killed
+	mockStore.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
+		return w.ID == 50 && w.State == model.StatusKilled
+	})).Return(nil)
+
+	count := ReconcileOrphaned(mockStore)
+	assert.Equal(t, 1, count)
+	mockStore.AssertCalled(t, "UpdatePipeline", mock.Anything)
+	mockStore.AssertCalled(t, "WorkflowUpdate", mock.Anything)
+}
+
+func TestReconcileOrphaned_SkipsPendingPipelines(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+
+	repos := []*model.Repo{
+		{ID: 1, FullName: "org/repo"},
+	}
+	mockStore.On("RepoListAll", true, mock.Anything).Return(repos, nil)
+
+	// Only pending pipeline — should NOT be killed (queue will handle it)
+	pipelines := []*model.Pipeline{
+		{ID: 200, Number: 42, Status: model.StatusPending, RepoID: 1},
+	}
+	mockStore.On("GetActivePipelineList", repos[0]).Return(pipelines, nil)
+
+	count := ReconcileOrphaned(mockStore)
+	assert.Equal(t, 0, count)
+	mockStore.AssertNotCalled(t, "UpdatePipeline", mock.Anything)
+}
+
+func TestReconcileOrphaned_NoActiveRepos(t *testing.T) {
+	mockStore := mocks.NewMockStore(t)
+
+	mockStore.On("RepoListAll", true, mock.Anything).Return([]*model.Repo{}, nil)
+
+	count := ReconcileOrphaned(mockStore)
+	assert.Equal(t, 0, count)
+}


### PR DESCRIPTION
## Summary

Two fixes for ghost tasks that persist in the queue after agent death:

### Part 1: Cancel calls queue.Done() for running workflows
`Cancel()` now calls `queue.Done()` for each running workflow in addition to `ErrorAtOnce()`. This ensures the task is removed from the queue's `running` map even when the agent is dead and can't call `rpc.Done()`.

### Part 2: Startup reconciliation
`ReconcileOrphaned()` runs at server startup. It finds pipelines stuck in "running" state with no corresponding queue task (lost when the in-memory queue was destroyed on restart) and marks them as killed. Also updates their running workflows.

## Root Cause

When a pipeline is canceled:
- `ErrorAtOnce()` removes pending/waiting tasks from the queue
- Running tasks stay in the queue's `running` map, assigned to the (dead) agent
- The agent is supposed to call `rpc.Done()` but dead agents never do
- Subsequent cancel calls fail with "Cannot cancel a non-running pipeline" because the DB status is already "killed"
- After server restart, the queue is empty but DB still shows pipelines as "running"

## Test Plan
- [x] `TestCancel_RunningWorkflow_QueueDone` — RED→GREEN: verifies Done() called for running workflows
- [x] `TestReconcileOrphaned_KillsRunningPipelines` — running pipeline marked as killed on startup
- [x] `TestReconcileOrphaned_SkipsPendingPipelines` — pending pipelines left alone
- [x] `TestReconcileOrphaned_NoActiveRepos` — empty repo list handled
- [x] All existing cancel tests pass (updated to expect Done() calls)
- [x] Pre-commit hooks pass

Fixes ci-infrastructure#891

🤖 Generated with [Claude Code](https://claude.com/claude-code)