### PR TITLE
fix: ReleaseAgentTasks completes full pipeline lifecycle (#4)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: ReleaseAgentTasks completes full pipeline lifecycle on agent disconnect — kills pending steps, finalizes parent pipeline, pushes status to GitHub. Previously only updated workflow, leaving pipeline as ghost and PR checks stuck at null (woodpecker-server#4)
 - Fix: ReleaseAgentTasks also updates pipeline database — queue was released but pipelines stayed `running` in DB, causing ghost pipelines visible to scaler (woodpecker-server#3)
 - Fix: WS agent reconnect backoff — linear delay (5s, 10s, 15s... up to 60s) when connections drop immediately. Prevents tight reconnect loops during server startup (woodpecker-server#3)
 - Fix: immediate task release on WebSocket agent disconnect — cleanup() calls ReleaseAgentTasks() to free running tasks in milliseconds instead of waiting 15min TaskTimeout. Prevents orphaned VMs from running idle (woodpecker-server#3)

--- a/server/rpc/release_agent_tasks_test.go
+++ b/server/rpc/release_agent_tasks_test.go
@@ -1,0 +1,123 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	"go.woodpecker-ci.org/woodpecker/v3/server/queue"
+	store_mocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+// stubQueue implements queue.Queue with minimal stubs for testing.
+type stubQueue struct {
+	info          queue.InfoT
+	errorAtOnce   error
+	errorAtOnceFn func(ids []string)
+}
+
+func (q *stubQueue) PushAtOnce(context.Context, []*model.Task) error { return nil }
+func (q *stubQueue) Poll(context.Context, int64, queue.FilterFn) (*model.Task, error) {
+	return nil, nil
+}
+func (q *stubQueue) Extend(context.Context, int64, string) error           { return nil }
+func (q *stubQueue) Done(context.Context, string, model.StatusValue) error { return nil }
+func (q *stubQueue) Error(context.Context, string, error) error            { return nil }
+func (q *stubQueue) ErrorAtOnce(_ context.Context, ids []string, _ error) error {
+	if q.errorAtOnceFn != nil {
+		q.errorAtOnceFn(ids)
+	}
+	return q.errorAtOnce
+}
+func (q *stubQueue) Wait(context.Context, string) error { return nil }
+func (q *stubQueue) Info(context.Context) queue.InfoT   { return q.info }
+func (q *stubQueue) Pause()                             {}
+func (q *stubQueue) Resume()                            {}
+func (q *stubQueue) KickAgentWorkers(int64)             {}
+func (q *stubQueue) SetDispatchHook(queue.DispatchFunc) {}
+
+func TestReleaseAgentTasks_NoOrphanedTasks(t *testing.T) {
+	q := &stubQueue{info: queue.InfoT{}}
+	s := store_mocks.NewMockStore(t)
+	rpc := RPC{queue: q, store: s}
+
+	// Should return immediately without any store calls
+	rpc.ReleaseAgentTasks(context.Background(), 99)
+}
+
+func TestReleaseAgentTasks_KillsWorkflowAndPipeline(t *testing.T) {
+	// Simulate agent 42 running workflow "100"
+	q := &stubQueue{
+		info: queue.InfoT{
+			Running: []*model.Task{
+				{ID: "100", AgentID: 42},
+			},
+		},
+	}
+
+	s := store_mocks.NewMockStore(t)
+
+	step1 := &model.Step{ID: 1, State: model.StatusRunning}
+	step2 := &model.Step{ID: 2, State: model.StatusPending}
+
+	workflow := &model.Workflow{
+		ID:         100,
+		PipelineID: 200,
+		State:      model.StatusRunning,
+	}
+
+	pipelineModel := &model.Pipeline{
+		ID:     200,
+		RepoID: 300,
+		Status: model.StatusRunning,
+	}
+
+	repo := &model.Repo{ID: 300, FullName: "test/repo"}
+
+	// Mock store calls in order
+	s.On("WorkflowLoad", int64(100)).Return(workflow, nil)
+	s.On("StepListFromWorkflowFind", workflow).Return([]*model.Step{step1, step2}, nil)
+	s.On("StepUpdate", mock.MatchedBy(func(step *model.Step) bool {
+		return step.State == model.StatusKilled && step.Error == "agent disconnected"
+	})).Return(nil)
+	s.On("WorkflowUpdate", mock.MatchedBy(func(w *model.Workflow) bool {
+		return w.State == model.StatusKilled && w.Error == "agent disconnected" && w.Finished > 0
+	})).Return(nil)
+	s.On("GetPipeline", int64(200)).Return(pipelineModel, nil)
+	s.On("WorkflowGetTree", pipelineModel).Return([]*model.Workflow{
+		{ID: 100, State: model.StatusKilled, Finished: 1},
+	}, nil)
+	s.On("UpdatePipeline", mock.MatchedBy(func(p *model.Pipeline) bool {
+		return p.Status == model.StatusKilled && p.Finished > 0
+	})).Return(nil)
+	s.On("GetRepo", int64(300)).Return(repo, nil)
+	// updateForgeStatus calls GetUser — allow it to fail gracefully
+	s.On("GetUser", mock.Anything).Return(nil, assert.AnError)
+
+	rpc := RPC{queue: q, store: s}
+	rpc.ReleaseAgentTasks(context.Background(), 42)
+
+	s.AssertExpectations(t)
+}
+
+func TestReleaseAgentTasks_OnlyReleasesMatchingAgent(t *testing.T) {
+	// Agent 42 has a task, agent 99 does not — releasing 99 should be a no-op
+	q := &stubQueue{
+		info: queue.InfoT{
+			Running: []*model.Task{
+				{ID: "100", AgentID: 42},
+			},
+		},
+	}
+
+	s := store_mocks.NewMockStore(t)
+	rpc := RPC{queue: q, store: s}
+
+	rpc.ReleaseAgentTasks(context.Background(), 99)
+
+	// No store calls should have been made
+	s.AssertNotCalled(t, "WorkflowLoad", mock.Anything)
+}

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -152,11 +152,10 @@ func (s *RPC) Extend(c context.Context, workflowID string) error {
 	return s.queue.Extend(c, agent.ID, workflowID)
 }
 
-// ReleaseAgentTasks releases all running tasks assigned to a dead agent (#3).
+// ReleaseAgentTasks releases all running tasks assigned to a dead agent (#3, #4).
 // Called when a WebSocket connection drops — releases tasks immediately
 // instead of waiting for TaskTimeout (15 minutes).
-// Updates both the queue (removes running task) AND the pipeline database
-// (marks workflow/pipeline as killed).
+// Updates the queue, workflow, steps, parent pipeline, and forge status (GitHub).
 func (s *RPC) ReleaseAgentTasks(c context.Context, agentID int64) {
 	info := s.queue.Info(c)
 	var orphaned []string
@@ -176,27 +175,82 @@ func (s *RPC) ReleaseAgentTasks(c context.Context, agentID int64) {
 		log.Error().Err(err).Msg("failed to release agent tasks from queue")
 	}
 
-	// Update pipeline database — mark workflows as killed so
-	// GetActivePipelineDetails doesn't see them as running (#3)
+	// Update pipeline database — mirror the completion logic from rpc.Done()
+	// so the pipeline reaches a terminal state and GitHub gets notified (#4)
 	for _, workflowIDStr := range orphaned {
 		workflowID, err := strconv.ParseInt(workflowIDStr, 10, 64)
 		if err != nil {
 			continue
 		}
+
 		workflow, err := s.store.WorkflowLoad(workflowID)
 		if err != nil {
 			log.Error().Err(err).Int64("workflow_id", workflowID).
-				Msg("failed to load orphaned workflow")
+				Msg("release: failed to load workflow")
 			continue
 		}
-		now := time.Now().Unix()
-		if _, err := pipeline.UpdateWorkflowStatusToDone(s.store, *workflow, rpc.WorkflowState{
-			Finished: now,
-			Error:    "agent disconnected",
-		}); err != nil {
+
+		// Load children (steps) so WorkflowStatus can evaluate them
+		workflow.Children, err = s.store.StepListFromWorkflowFind(workflow)
+		if err != nil {
 			log.Error().Err(err).Int64("workflow_id", workflowID).
-				Msg("failed to mark orphaned workflow as done")
+				Msg("release: failed to load workflow steps")
 		}
+
+		now := time.Now().Unix()
+
+		// Mark pending/running steps as killed
+		for _, step := range workflow.Children {
+			if step.Running() || step.State == model.StatusPending {
+				step.State = model.StatusKilled
+				step.Finished = now
+				step.Error = "agent disconnected"
+				if err := s.store.StepUpdate(step); err != nil {
+					log.Error().Err(err).Int64("step_id", step.ID).
+						Msg("release: failed to kill step")
+				}
+			}
+		}
+
+		// Mark workflow as killed
+		workflow.State = model.StatusKilled
+		workflow.Finished = now
+		workflow.Error = "agent disconnected"
+		if err := s.store.WorkflowUpdate(workflow); err != nil {
+			log.Error().Err(err).Int64("workflow_id", workflowID).
+				Msg("release: failed to kill workflow")
+		}
+
+		// Update parent pipeline status
+		currentPipeline, err := s.store.GetPipeline(workflow.PipelineID)
+		if err != nil {
+			log.Error().Err(err).Int64("pipeline_id", workflow.PipelineID).
+				Msg("release: failed to load pipeline")
+			continue
+		}
+
+		currentPipeline.Workflows, err = s.store.WorkflowGetTree(currentPipeline)
+		if err != nil {
+			log.Error().Err(err).Int64("pipeline_id", currentPipeline.ID).
+				Msg("release: failed to load workflow tree")
+			continue
+		}
+
+		if !model.IsThereRunningStage(currentPipeline.Workflows) {
+			if _, err := pipeline.UpdateStatusToDone(s.store, *currentPipeline, pipeline.PipelineStatus(currentPipeline.Workflows), now); err != nil {
+				log.Error().Err(err).Int64("pipeline_id", currentPipeline.ID).
+					Msg("release: failed to finalize pipeline")
+			}
+		}
+
+		// Push status to GitHub so PR checks update
+		repo, err := s.store.GetRepo(currentPipeline.RepoID)
+		if err != nil {
+			log.Error().Err(err).Int64("repo_id", currentPipeline.RepoID).
+				Msg("release: failed to load repo")
+			continue
+		}
+		s.updateForgeStatus(c, repo, currentPipeline, workflow)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `ReleaseAgentTasks` now completes the full pipeline lifecycle on agent disconnect:
  - Kills pending/running steps (marks as `killed` with error "agent disconnected")
  - Finalizes parent pipeline status (no more ghost pipelines stuck at `running`)
  - Pushes forge status to GitHub (PR checks update instead of staying null)
- 3 new tests covering no-op, full lifecycle, and agent filtering

## Root Cause
The original woodpecker-server#3 fix released the queue task and updated the workflow, but missed:
1. Loading and killing child steps
2. Updating the parent pipeline to a terminal state
3. Pushing the status to GitHub via `updateForgeStatus`

This left pipelines as ghosts — `status: running` in DB with no queue task.

## Test plan
- [x] `TestReleaseAgentTasks_NoOrphanedTasks` — no-op when no matching tasks
- [x] `TestReleaseAgentTasks_KillsWorkflowAndPipeline` — full lifecycle: steps killed, workflow killed, pipeline finalized
- [x] `TestReleaseAgentTasks_OnlyReleasesMatchingAgent` — only releases tasks for the disconnected agent
- [x] All existing RPC tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)