### PR TITLE
fix: WebSocket ping/pong keepalive (#5)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: WebSocket ping/pong keepalive — server pings agents every 30s, expects pong within 60s. Prevents Caddy/GCP firewall/NAT from dropping idle connections. 323 agent disconnects in 10 hours without this (woodpecker-server#5)
 - Fix: pts-build pipeline uses on-demand tier — Docker builds take 10-20min, spot VMs preempted every time (woodpecker-server#4)
 - Fix: ReleaseAgentTasks completes full pipeline lifecycle on agent disconnect — kills pending steps, finalizes parent pipeline, pushes status to GitHub. Previously only updated workflow, leaving pipeline as ghost and PR checks stuck at null (woodpecker-server#4)
 - Fix: ReleaseAgentTasks also updates pipeline database — queue was released but pipelines stayed `running` in DB, causing ghost pipelines visible to scaler (woodpecker-server#3)

--- a/server/api/ws_agent.go
+++ b/server/api/ws_agent.go
@@ -22,6 +22,12 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/version"
 )
 
+const (
+	wsPingInterval = 30 * time.Second // server sends ping every 30s
+	wsPongWait     = 60 * time.Second // client must respond within 60s
+	wsWriteWait    = 10 * time.Second // write deadline for control frames
+)
+
 var agentUpgrader = websocket.Upgrader{
 	CheckOrigin: func(_ *http.Request) bool { return true },
 }
@@ -72,6 +78,15 @@ func WSAgent(c *gin.Context) {
 		cancelWaiters: make(map[string]context.CancelFunc),
 	}
 
+	// WebSocket keepalive — ping/pong prevents intermediate network
+	// hops (Caddy, GCP firewall, NAT) from dropping idle connections (#5)
+	conn.SetReadDeadline(time.Now().Add(wsPongWait))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(wsPongWait))
+		return nil
+	})
+	go state.pingLoop(connCtx)
+
 	// Send version on connect
 	state.send(MsgVersion, "", VersionPayload{
 		ServerVersion: version.String(),
@@ -110,6 +125,26 @@ type wsAgentState struct {
 	store         store.Store
 	agentID       int64
 	cancelWaiters map[string]context.CancelFunc // workflowID → cancel func for Wait goroutines
+}
+
+// pingLoop sends WebSocket ping frames at regular intervals.
+// Stops when the connection context is canceled.
+func (s *wsAgentState) pingLoop(ctx context.Context) {
+	ticker := time.NewTicker(wsPingInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.writeMu.Lock()
+			err := s.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(wsWriteWait))
+			s.writeMu.Unlock()
+			if err != nil {
+				return
+			}
+		}
+	}
 }
 
 func (s *wsAgentState) cleanup() {


### PR DESCRIPTION
## Summary

- Server sends WebSocket ping every 30s, expects pong within 60s
- Prevents Caddy/GCP firewall/NAT from dropping idle TCP connections
- Without this: 323 agent disconnects across 84 agents in 10 hours, 0% CI success rate

## Test plan

- [x] `go build ./server/...` passes
- [x] `go test ./server/api/...` passes
- [x] `go vet` clean
- [ ] Deploy to d3ci42, verify agents stay connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)