### PR TITLE
fix: safe SQLite DSN defaults prevent 'database is locked' 500s (#10)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix: apply safe SQLite DSN defaults (`_busy_timeout=30000`, `_journal_mode=WAL`, `_synchronous=NORMAL`, `_txlock=immediate`) automatically when driver is sqlite3. Operator-supplied values win. Prevents `database is locked` 500s on `/api/hook` under concurrent webhook bursts (woodpecker-server#10)
 - Fix: ReleaseAgentTasks logs ghost running tasks with mismatched AgentID — diagnostic for orphaned queue entries after clean disconnect (woodpecker-server#8)
 - Fix: pts-build uses flock on docker-compose.yml to prevent concurrent sed race with scaler deploy (peregrine-ci-scaler#330)
 - Feat: `superseded` pipeline status distinct from `killed` — pipelines canceled by a newer push on the same branch now show `superseded` instead of `killed`. Separates expected behavior (rapid merges) from real problems (agent death, timeout). Includes Pub/Sub event, all forge status mappings, badges, and Go client (woodpecker-server#7)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix: apply safe SQLite DSN defaults (`_busy_timeout=30000`, `_journal_mode=WAL`, `_synchronous=NORMAL`, `_txlock=immediate`) automatically when driver is sqlite3. Operator-supplied values win. Prevents `database is locked` 500s on `/api/hook` under concurrent webhook bursts (woodpecker-server#10)
+- Fix: pts-test.sh and pts-lint.sh export `/usr/local/go/bin` on PATH. Packer's `/etc/profile.d/go.sh` only runs for login shells; Woodpecker's non-login bash never sourced it, so every feature-branch CI run failed with `go: command not found` (woodpecker-server#11)
 - Fix: ReleaseAgentTasks logs ghost running tasks with mismatched AgentID — diagnostic for orphaned queue entries after clean disconnect (woodpecker-server#8)
 - Fix: pts-build uses flock on docker-compose.yml to prevent concurrent sed race with scaler deploy (peregrine-ci-scaler#330)
 - Feat: `superseded` pipeline status distinct from `killed` — pipelines canceled by a newer push on the same branch now show `superseded` instead of `killed`. Separates expected behavior (rapid merges) from real problems (agent death, timeout). Includes Pub/Sub event, all forge status mappings, badges, and Go client (woodpecker-server#7)

--- a/scripts/woodpecker/pts-lint.sh
+++ b/scripts/woodpecker/pts-lint.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Packer puts Go at /usr/local/go/bin; /etc/profile.d/go.sh adds it to PATH for
+# login shells only. This script runs under non-login bash, so export directly.
+export PATH="/usr/local/go/bin:$PATH"
+
 echo "==> Running go vet on Peregrine packages..."
 
 # Our packages only — skip web/, cmd/server/, server/router/ (need frontend build)

--- a/scripts/woodpecker/pts-test.sh
+++ b/scripts/woodpecker/pts-test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Packer puts Go at /usr/local/go/bin; /etc/profile.d/go.sh adds it to PATH for
+# login shells only. This script runs under non-login bash, so export directly.
+export PATH="/usr/local/go/bin:$PATH"
+
 echo "==> Running tests on Peregrine plugin packages..."
 
 # Our packages only — upstream packages are not our coverage responsibility

--- a/server/store/datastore/engine.go
+++ b/server/store/datastore/engine.go
@@ -32,7 +32,11 @@ type storage struct {
 const perPage = 50
 
 func NewEngine(opts *store.Opts) (store.Store, error) {
-	engine, err := xorm.NewEngine(opts.Driver, opts.Config)
+	dsn := opts.Config
+	if opts.Driver == "sqlite3" {
+		dsn = applySqliteDefaults(dsn)
+	}
+	engine, err := xorm.NewEngine(opts.Driver, dsn)
 	if err != nil {
 		return nil, err
 	}

--- a/server/store/datastore/sqlite_dsn.go
+++ b/server/store/datastore/sqlite_dsn.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Peregrine Technology Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package datastore
+
+import (
+	"net/url"
+	"strings"
+)
+
+// sqliteSafeDefaults is the minimum set of pragmas that lets Woodpecker
+// survive concurrent webhook bursts without SQLITE_BUSY "database is locked"
+// errors on /api/hook. See woodpecker-server#10 for the incident analysis.
+var sqliteSafeDefaults = map[string]string{
+	"_busy_timeout": "30000",
+	"_journal_mode": "WAL",
+	"_synchronous":  "NORMAL",
+	"_txlock":       "immediate",
+}
+
+// applySqliteDefaults merges sqliteSafeDefaults into the DSN, preserving any
+// value the operator has already set. Invoked from NewEngine when the driver
+// is sqlite3.
+func applySqliteDefaults(dsn string) string {
+	base, rawQuery := splitSqliteDSN(dsn)
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		values = url.Values{}
+	}
+	for k, v := range sqliteSafeDefaults {
+		if values.Get(k) == "" {
+			values.Set(k, v)
+		}
+	}
+	return base + "?" + values.Encode()
+}
+
+func splitSqliteDSN(dsn string) (base, query string) {
+	if i := strings.Index(dsn, "?"); i >= 0 {
+		return dsn[:i], dsn[i+1:]
+	}
+	return dsn, ""
+}

--- a/server/store/datastore/sqlite_dsn_test.go
+++ b/server/store/datastore/sqlite_dsn_test.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Peregrine Technology Systems
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+
+package datastore
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestApplySqliteDefaults(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantKV  map[string]string
+		wantRaw string
+	}{
+		{
+			name: "plain path adds all defaults",
+			in:   "/var/lib/woodpecker/woodpecker.sqlite",
+			wantKV: map[string]string{
+				"_busy_timeout": "30000",
+				"_journal_mode": "WAL",
+				"_synchronous":  "NORMAL",
+				"_txlock":       "immediate",
+			},
+		},
+		{
+			name: "file URI with no params adds all defaults",
+			in:   "file:/var/lib/woodpecker/woodpecker.sqlite",
+			wantKV: map[string]string{
+				"_busy_timeout": "30000",
+				"_journal_mode": "WAL",
+				"_synchronous":  "NORMAL",
+				"_txlock":       "immediate",
+			},
+		},
+		{
+			name: "user-supplied busy_timeout wins",
+			in:   "/db.sqlite?_busy_timeout=60000",
+			wantKV: map[string]string{
+				"_busy_timeout": "60000",
+				"_journal_mode": "WAL",
+				"_synchronous":  "NORMAL",
+				"_txlock":       "immediate",
+			},
+		},
+		{
+			name: "user-supplied journal_mode wins",
+			in:   "/db.sqlite?_journal_mode=DELETE",
+			wantKV: map[string]string{
+				"_journal_mode": "DELETE",
+				"_busy_timeout": "30000",
+				"_synchronous":  "NORMAL",
+				"_txlock":       "immediate",
+			},
+		},
+		{
+			name: "all user-supplied preserved",
+			in:   "/db.sqlite?_busy_timeout=1000&_journal_mode=MEMORY&_synchronous=OFF&_txlock=deferred",
+			wantKV: map[string]string{
+				"_busy_timeout": "1000",
+				"_journal_mode": "MEMORY",
+				"_synchronous":  "OFF",
+				"_txlock":       "deferred",
+			},
+		},
+		{
+			name: "unrelated params preserved alongside defaults",
+			in:   "/db.sqlite?cache=shared&mode=rwc",
+			wantKV: map[string]string{
+				"cache":         "shared",
+				"mode":          "rwc",
+				"_busy_timeout": "30000",
+				"_journal_mode": "WAL",
+				"_synchronous":  "NORMAL",
+				"_txlock":       "immediate",
+			},
+		},
+		{
+			name: "in-memory sqlite stays in-memory",
+			in:   ":memory:",
+			wantKV: map[string]string{
+				"_busy_timeout": "30000",
+				"_journal_mode": "WAL",
+				"_synchronous":  "NORMAL",
+				"_txlock":       "immediate",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applySqliteDefaults(tc.in)
+			base, query := splitDSN(got)
+			if base == "" {
+				t.Fatalf("applySqliteDefaults(%q) returned empty base; got %q", tc.in, got)
+			}
+			values, err := url.ParseQuery(query)
+			if err != nil {
+				t.Fatalf("ParseQuery(%q): %v", query, err)
+			}
+			for k, want := range tc.wantKV {
+				if got := values.Get(k); got != want {
+					t.Errorf("%s: key %q = %q, want %q (full DSN: %q)", tc.name, k, got, want, got)
+				}
+			}
+		})
+	}
+}
+
+func TestApplySqliteDefaults_IdempotentOnRepeatedCall(t *testing.T) {
+	once := applySqliteDefaults("/db.sqlite")
+	twice := applySqliteDefaults(once)
+	if once != twice {
+		t.Errorf("not idempotent:\n  once:  %q\n  twice: %q", once, twice)
+	}
+}
+
+func splitDSN(dsn string) (base, query string) {
+	if i := strings.Index(dsn, "?"); i >= 0 {
+		return dsn[:i], dsn[i+1:]
+	}
+	return dsn, ""
+}


### PR DESCRIPTION
## Summary

Fixes [woodpecker-server#10](https://github.com/Peregrine-Technology-Systems/woodpecker-server/issues/10).

When `WOODPECKER_DATABASE_DRIVER=sqlite3` and the operator hasn't set `WOODPECKER_DATABASE_DATASOURCE`, the server uses a bare file path with no SQLite parameters. That means `busy_timeout=0` and `journal_mode=DELETE` — so the first concurrent writer wins and the rest get `SQLITE_BUSY` → `"database is locked"` → HTTP 500 to GitHub's webhook delivery.

On d3ci42 this produced 6 missed pipelines in a single day (2026-04-19): merges, tags, and promotions silently skipped because their webhook 500'd.

## Change

New helper `applySqliteDefaults` (in a new file `server/store/datastore/sqlite_dsn.go`) merges four safe defaults into the DSN:

- `_busy_timeout=30000` — wait instead of failing
- `_journal_mode=WAL` — concurrent readers + one writer
- `_synchronous=NORMAL` — fewer fsyncs (safe under WAL)
- `_txlock=immediate` — grab write lock at BEGIN, avoid upgrade deadlocks

Operator-supplied values always win — we only fill in what's missing.

`NewEngine` calls this when `opts.Driver == "sqlite3"`; other drivers (postgres, mysql) are untouched.

## Test plan

- [x] Table-driven tests in `sqlite_dsn_test.go`:
  - plain path
  - `file:` URI
  - user-supplied `_busy_timeout` preserved
  - user-supplied `_journal_mode` preserved
  - all four user-supplied preserved
  - unrelated params preserved alongside defaults (`?cache=shared`)
  - `:memory:` still works
- [x] Idempotency test — `applySqliteDefaults(applySqliteDefaults(x)) == applySqliteDefaults(x)`
- [x] `go build ./...` clean
- [x] Full `server/store/datastore/` test suite passes

## Rollout

1. Merge to main.
2. Rebuild `woodpecker-server` image (tag `v3.13.0-pts.52`) on pentest-dev-vm.
3. Update d3ci42 `/opt/woodpecker/docker-compose.yml` and restart `woodpecker-woodpecker-server-1`.
4. Verify no new `database is locked` errors after ~1h under normal webhook traffic.