### PR TITLE
fix: skip corrupt-JSON rows in pipeline listings instead of returning 500 (#38)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: skip corrupt-JSON rows in pipeline listings instead of returning 500 (#38). A single row with a non-JSON value in `errors`, `cancel_info`, or any other JSON-tagged column caused `GetPipelineList`, `GetRepoLatestPipelines`, and `GetActivePipelineList` to fail the entire page with HTTP 500. Now uses a `Rows` cursor so each row is decoded individually — a bad row logs a `WARN` and is skipped; valid rows are returned normally. Incident 2026-04-27: one operator SQL write produced 15h of 500s across 13 repos.
+
 - fix: use `systemctl restart` not `reload-or-restart` for woodpecker-server in pts-build.sh. `reload-or-restart` sends SIGHUP; woodpecker-server exits on SIGHUP rather than reloading, taking the server down on every pts-build deploy and generating up/down Slack alerts. Fixed in both the deploy path and rollback path.
 
 - feat: GCS build cache for pts-build (#851). Restores Go build cache + module cache from `gs://ci-runners-de-build-cache/` at build start, saves back after compile. Warm cache reduces compile time ~8 min → ~1 min. Best-effort: non-fatal on cache miss or save failure.

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
+	"github.com/rs/zerolog/log"
 	"xorm.io/builder"
 	"xorm.io/xorm"
 
@@ -66,8 +67,6 @@ func (s storage) GetPipelineLastBefore(repo *model.Repo, branch string, num int6
 }
 
 func (s storage) GetPipelineList(repo *model.Repo, p *model.ListOptions, f *model.PipelineFilter) ([]*model.Pipeline, error) {
-	pipelines := make([]*model.Pipeline, 0, 16)
-
 	cond := builder.NewCond().And(builder.Eq{"repo_id": repo.ID})
 
 	if f != nil {
@@ -98,15 +97,11 @@ func (s storage) GetPipelineList(repo *model.Repo, p *model.ListOptions, f *mode
 		}
 	}
 
-	return pipelines, s.paginate(p).Where(cond).
-		Desc("number").
-		Find(&pipelines)
+	return scanPipelines(s.paginate(p).Where(cond).Desc("number"))
 }
 
 // GetRepoLatestPipelines get the latest pipeline for each repo.
 func (s storage) GetRepoLatestPipelines(repoIDs []int64) ([]*model.Pipeline, error) {
-	pipelines := make([]*model.Pipeline, 0, len(repoIDs))
-
 	pipelineIDs := make([]int64, 0, len(repoIDs))
 	if err := s.engine.Select("MAX(id) AS id").
 		Table("pipelines").
@@ -116,17 +111,39 @@ func (s storage) GetRepoLatestPipelines(repoIDs []int64) ([]*model.Pipeline, err
 		return nil, err
 	}
 
-	return pipelines, s.engine.Where(builder.In("id", pipelineIDs)).Find(&pipelines)
+	return scanPipelines(s.engine.Where(builder.In("id", pipelineIDs)))
 }
 
 // GetActivePipelineList get all pipelines that are pending, running or blocked.
 func (s storage) GetActivePipelineList(repo *model.Repo) ([]*model.Pipeline, error) {
-	pipelines := make([]*model.Pipeline, 0)
-	query := s.engine.
+	return scanPipelines(s.engine.
 		Where("repo_id = ?", repo.ID).
 		In("status", model.StatusPending, model.StatusRunning, model.StatusBlocked).
-		Desc("number")
-	return pipelines, query.Find(&pipelines)
+		Desc("number"))
+}
+
+// scanPipelines iterates rows from the given xorm session using a cursor so
+// that a single row with a corrupt JSON column (e.g. errors, cancel_info) is
+// skipped and logged rather than failing the entire listing with HTTP 500.
+// Incident 2026-04-27: one bad row in `errors` caused 15 hours of 500s across
+// 13 repos (peregrine-ci-infrastructure#1221, fork#38).
+func scanPipelines(sess *xorm.Session) ([]*model.Pipeline, error) {
+	rows, err := sess.Rows(new(model.Pipeline))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var pipelines []*model.Pipeline
+	for rows.Next() {
+		p := new(model.Pipeline)
+		if err := rows.Scan(p); err != nil {
+			log.Warn().Err(err).Msg("pipeline listing: skipping row with corrupt JSON column")
+			continue
+		}
+		pipelines = append(pipelines, p)
+	}
+	return pipelines, rows.Err()
 }
 
 func (s storage) GetPipelineCount() (int64, error) {

--- a/server/store/datastore/pipeline_test.go
+++ b/server/store/datastore/pipeline_test.go
@@ -281,3 +281,41 @@ func TestDeletePipeline(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, 1, count)
 }
+
+// TestGetPipelineList_CorruptJSONColumn verifies that a single row with a
+// corrupt JSON column (e.g. plain text in `errors`) does not poison the entire
+// listing with a 500. The bad row is skipped; valid rows are returned.
+// Regression for fork#38 / incident 2026-04-27 (peregrine-ci-infrastructure#1221).
+func TestGetPipelineList_CorruptJSONColumn(t *testing.T) {
+	repo := &model.Repo{
+		UserID:   1,
+		FullName: "owner/repo",
+		Owner:    "owner",
+		Name:     "repo",
+	}
+
+	store, closer := newTestStore(t, new(model.Repo), new(model.Pipeline))
+	defer closer()
+
+	require.NoError(t, store.CreateRepo(repo))
+
+	good := &model.Pipeline{RepoID: repo.ID, Status: model.StatusSuccess, Event: model.EventPush, Branch: "main"}
+	require.NoError(t, store.CreatePipeline(good))
+
+	bad := &model.Pipeline{RepoID: repo.ID, Status: model.StatusError, Event: model.EventPush, Branch: "main"}
+	require.NoError(t, store.CreatePipeline(bad))
+
+	// Corrupt the `errors` column of the bad row with plain text — the exact
+	// scenario from the 2026-04-27 incident where operator SQL wrote
+	// "forced terminal: <msg>" into a JSON column.
+	_, err := store.engine.Exec(
+		"UPDATE pipelines SET errors = ? WHERE id = ?",
+		"forced terminal: not valid json", bad.ID,
+	)
+	require.NoError(t, err)
+
+	pipelines, err := store.GetPipelineList(repo, &model.ListOptions{Page: 1, PerPage: 50}, nil)
+	assert.NoError(t, err, "listing must not fail due to single corrupt row")
+	assert.Len(t, pipelines, 1, "corrupt row skipped; good row returned")
+	assert.Equal(t, good.ID, pipelines[0].ID)
+}


### PR DESCRIPTION
## Summary

- Replaces `Find(&pipelines)` with a `Rows` cursor in a new `scanPipelines` helper across `GetPipelineList`, `GetRepoLatestPipelines`, and `GetActivePipelineList`
- A single row with a non-JSON value in any `xorm:"json '...'"` column is now skipped with a `WARN` log rather than failing the entire page with HTTP 500
- Adds `TestGetPipelineList_CorruptJSONColumn` — injects plain text into the `errors` column of one row; asserts listing returns remaining valid rows without error

## Background

Incident 2026-04-27: one operator SQL wrote plain text into the `errors` column. The xorm `Find` tried to unmarshal every row — one bad row aborted the scan, returning HTTP 500 for the entire listing across 13 repos for 15 hours (peregrine-ci-infrastructure#1221).

## Test plan

- [x] `TestGetPipelineList_CorruptJSONColumn` passes — bad row skipped, good row returned, no error
- [x] All existing pipeline store tests pass
- [x] Full `./server/store/datastore/...` suite green

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/claude-code)