### PR TITLE
fix: restore backend:local in pts-build — GCP agent path broken (pipelines 106, 110)

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -2,10 +2,9 @@ when:
   - event: push
     branch: main
 
-clone:
-  git:
-    settings:
-      lfs: false
+labels:
+  platform: linux
+  backend: local
 
 steps:
   - name: build-and-push

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-- fix: disable git lfs in pts-build clone step — GCP agents lack git-lfs, causing clone exit 1 (pipeline 106). `backend: local` previously skipped the clone step; normal agents run it unconditionally. Long-term fix: add git-lfs to Packer image (peregrine-infrastructure).
-
 - feat: pts-build compiles on pentest-dev-vm instead of d3ci42 (#67). Removes `backend: local` from pts-build.yaml so the pipeline runs on a normal CI agent. The compile step SSHes to pentest-dev-vm (GCP, peregrine-pentest-dev project), clones woodpecker, restores GCS build cache, runs pnpm + CGO go build, saves cache, then rsyncs binaries back. pentest-dev-vm is started at build start and stopped in an EXIT trap (success or failure). d3ci42 no longer needs Node/pnpm/GCC. GCS warm cache (~3.3 GiB) still cuts compile to ~1 min.
 
 - fix: skip corrupt-JSON rows in pipeline listings instead of returning 500 (#38). A single row with a non-JSON value in `errors`, `cancel_info`, or any other JSON-tagged column caused `GetPipelineList`, `GetRepoLatestPipelines`, and `GetActivePipelineList` to fail the entire page with HTTP 500. Now uses a `Rows` cursor so each row is decoded individually — a bad row logs a `WARN` and is skipped; valid rows are returned normally. Incident 2026-04-27: one operator SQL write produced 15h of 500s across 13 repos.


### PR DESCRIPTION
Two problems when running pts-build on a normal GCP agent: (1) clone exit 1 — git-lfs not in Packer image; (2) `clone:git:settings:lfs:false` broke YAML parse → workflows=null. Restoring `backend: local` avoids the clone step entirely. pts-build.sh still SSHes to pentest-dev-vm for compile — d3ci42 only orchestrates. Long-term: add git-lfs to Packer image.