### PR TITLE
fix: SSH keepalive on pentest-dev connections — silent compile dropped session (#112)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: add SSH keepalive to pentest-dev connections in pts-build.sh — CGO compile is silent for several minutes, causing the SSH server to close the session as apparently idle. `ServerAliveInterval=30 ServerAliveCountMax=10` keeps the client pinging every 30s for up to 5 min of missed responses. Incident: pipeline 112 failed after 20 min with "Connection closed by remote host". Applied to both the main `PTS_SSH` var and the rsync `-e` flag.
+
 - feat: pts-build compiles on pentest-dev-vm instead of d3ci42 (#67). Removes `backend: local` from pts-build.yaml so the pipeline runs on a normal CI agent. The compile step SSHes to pentest-dev-vm (GCP, peregrine-pentest-dev project), clones woodpecker, restores GCS build cache, runs pnpm + CGO go build, saves cache, then rsyncs binaries back. pentest-dev-vm is started at build start and stopped in an EXIT trap (success or failure). d3ci42 no longer needs Node/pnpm/GCC. GCS warm cache (~3.3 GiB) still cuts compile to ~1 min.
 
 - fix: skip corrupt-JSON rows in pipeline listings instead of returning 500 (#38). A single row with a non-JSON value in `errors`, `cancel_info`, or any other JSON-tagged column caused `GetPipelineList`, `GetRepoLatestPipelines`, and `GetActivePipelineList` to fail the entire page with HTTP 500. Now uses a `Rows` cursor so each row is decoded individually — a bad row logs a `WARN` and is skipped; valid rows are returned normally. Incident 2026-04-27: one operator SQL write produced 15h of 500s across 13 repos.

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -46,7 +46,7 @@ PTS_KEY=".deploy-ssh/pts-build-key"
 echo "$PTS_BUILD_SSH_KEY" > "$PTS_KEY"
 printf '\n' >> "$PTS_KEY"
 chmod 600 "$PTS_KEY"
-PTS_SSH="ssh -i $PTS_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
+PTS_SSH="ssh -i $PTS_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
 
 # ── Start pentest-dev-vm ──
 echo ""
@@ -129,7 +129,7 @@ echo ""
 echo "==> Fetching binaries from pentest-dev..."
 mkdir -p bin
 rsync -az \
-    -e "ssh -i $PTS_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
+    -e "ssh -i $PTS_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10" \
     "root@${PENTEST_IP}:${WORK_DIR}/bin/" bin/
 echo "    server: $(du -h bin/woodpecker-server | cut -f1)  agent: $(du -h bin/woodpecker-agent | cut -f1)"
 # pentest-dev VM stopped by EXIT trap here


### PR DESCRIPTION
CGO compile produces no stdout for several minutes, causing the SSH server to close the connection as apparently idle (~15 min into pipeline 112). Adding `ServerAliveInterval=30 ServerAliveCountMax=10` keeps the client pinging every 30s.