### PR TITLE
fix: re-queue claimed-but-not-started tasks on agent disconnect (#72)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: re-queue claimed-but-not-started tasks on agent disconnect instead of killing them (#72). `ReleaseAgentTasks` now checks `workflow.Started` before acting: tasks with `Started == 0` are re-queued via `PushAtOnce` (agent claimed but never began executing — safe for another agent to pick up); tasks with `Started > 0` are killed as before. Incident 2026-05-05: scaler version-bump pipeline 1723 was killed in 4s with `started=0` because it was in the queue when agent 14450 disconnected. The bug was introduced when we built `ReleaseAgentTasks` in fork#3 — the fast-release path correctly replaced the 15-min TaskTimeout but didn't distinguish claimed vs running. Falls back to kill if re-queue fails or workflow can't be loaded.
+
 - fix: add SSH keepalive to pentest-dev connections in pts-build.sh — CGO compile is silent for several minutes, causing the SSH server to close the session as apparently idle. `ServerAliveInterval=30 ServerAliveCountMax=10` keeps the client pinging every 30s for up to 5 min of missed responses. Incident: pipeline 112 failed after 20 min with "Connection closed by remote host". Applied to both the main `PTS_SSH` var and the rsync `-e` flag.
 
 - feat: pts-build compiles on pentest-dev-vm instead of d3ci42 (#67). Removes `backend: local` from pts-build.yaml so the pipeline runs on a normal CI agent. The compile step SSHes to pentest-dev-vm (GCP, peregrine-pentest-dev project), clones woodpecker, restores GCS build cache, runs pnpm + CGO go build, saves cache, then rsyncs binaries back. pentest-dev-vm is started at build start and stopped in an EXIT trap (success or failure). d3ci42 no longer needs Node/pnpm/GCC. GCS warm cache (~3.3 GiB) still cuts compile to ~1 min.

--- a/server/rpc/release_agent_tasks_test.go
+++ b/server/rpc/release_agent_tasks_test.go
@@ -3,7 +3,9 @@ package grpc
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
@@ -16,9 +18,14 @@ type stubQueue struct {
 	info          queue.InfoT
 	errorAtOnce   error
 	errorAtOnceFn func(ids []string)
+	pushed        []*model.Task // tasks passed to PushAtOnce
+	errored       []string      // task IDs passed to ErrorAtOnce
 }
 
-func (q *stubQueue) PushAtOnce(context.Context, []*model.Task) error { return nil }
+func (q *stubQueue) PushAtOnce(_ context.Context, tasks []*model.Task) error {
+	q.pushed = append(q.pushed, tasks...)
+	return nil
+}
 func (q *stubQueue) Poll(context.Context, int64, queue.FilterFn) (*model.Task, error) {
 	return nil, nil
 }
@@ -26,6 +33,7 @@ func (q *stubQueue) Extend(context.Context, int64, string) error           { ret
 func (q *stubQueue) Done(context.Context, string, model.StatusValue) error { return nil }
 func (q *stubQueue) Error(context.Context, string, error) error            { return nil }
 func (q *stubQueue) ErrorAtOnce(_ context.Context, ids []string, _ error) error {
+	q.errored = append(q.errored, ids...)
 	if q.errorAtOnceFn != nil {
 		q.errorAtOnceFn(ids)
 	}
@@ -66,6 +74,7 @@ func TestReleaseAgentTasks_KillsWorkflowAndPipeline(t *testing.T) {
 		ID:         100,
 		PipelineID: 200,
 		State:      model.StatusRunning,
+		Started:    time.Now().Unix(), // Started > 0 → kill path, not re-queue (#72)
 	}
 
 	pipelineModel := &model.Pipeline{
@@ -123,4 +132,38 @@ func TestReleaseAgentTasks_OnlyReleasesMatchingAgent(t *testing.T) {
 
 	// No store calls should have been made
 	s.AssertNotCalled(t, "WorkflowLoad", mock.Anything)
+}
+
+// TestReleaseAgentTasks_RequeueClaimed verifies that a task claimed by a
+// disconnecting agent but not yet started (workflow.Started == 0) is
+// re-queued instead of killed. Regression test for fork#72.
+func TestReleaseAgentTasks_RequeueClaimed(t *testing.T) {
+	task := &model.Task{ID: "100", AgentID: 42}
+	q := &stubQueue{
+		info: queue.InfoT{
+			Running: []*model.Task{task},
+		},
+	}
+
+	// workflow.Started == 0: agent claimed but never began executing
+	workflow := &model.Workflow{
+		ID:         100,
+		PipelineID: 200,
+		State:      model.StatusPending,
+		Started:    0,
+	}
+
+	s := store_mocks.NewMockStore(t)
+	s.On("WorkflowLoad", int64(100)).Return(workflow, nil)
+
+	rpc := RPC{queue: q, store: s}
+	rpc.ReleaseAgentTasks(context.Background(), 42)
+
+	// Task must be re-queued, not killed
+	assert.Equal(t, []*model.Task{task}, q.pushed, "claimed task must be re-queued")
+	assert.Empty(t, q.errored, "claimed task must not be killed")
+
+	// No DB kill updates — the workflow never ran
+	s.AssertNotCalled(t, "StepListFromWorkflowFind", mock.Anything)
+	s.AssertNotCalled(t, "WorkflowUpdate", mock.Anything)
 }

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -157,12 +157,21 @@ func (s *RPC) Extend(c context.Context, workflowID string) error {
 // Called on EVERY WebSocket disconnect (clean or unexpected) — releases tasks
 // immediately instead of waiting for TaskTimeout (15 minutes).
 // Updates the queue, workflow, steps, parent pipeline, and forge status (GitHub).
+//
+// Tasks are split by whether execution had started (#72):
+//   - workflow.Started == 0: agent claimed the task but never began executing it.
+//     Safe to re-queue — another agent can pick it up with no work lost.
+//   - workflow.Started > 0: agent was mid-execution. Kill as before.
 func (s *RPC) ReleaseAgentTasks(c context.Context, agentID int64) {
 	info := s.queue.Info(c)
+
+	// Index running tasks by ID for O(1) lookup when re-queuing.
+	taskByID := make(map[string]*model.Task, len(info.Running))
 	var orphaned []string
 	for _, task := range info.Running {
 		if task.AgentID == agentID {
 			orphaned = append(orphaned, task.ID)
+			taskByID[task.ID] = task
 		}
 	}
 
@@ -181,24 +190,63 @@ func (s *RPC) ReleaseAgentTasks(c context.Context, agentID int64) {
 	log.Warn().Int64("agent_id", agentID).Int("tasks", len(orphaned)).
 		Msg("releasing tasks from disconnecting agent")
 
-	// Release from queue
-	if err := s.queue.ErrorAtOnce(c, orphaned, queue.ErrCancel); err != nil {
+	// Partition into claimed-but-not-started (re-queue) vs started (kill). (#72)
+	// Cache loaded workflows so the kill loop below doesn't load them a second time.
+	var toKill []string
+	var toRequeue []*model.Task
+	workflowCache := make(map[string]*model.Workflow, len(orphaned))
+	for _, workflowIDStr := range orphaned {
+		workflowID, err := strconv.ParseInt(workflowIDStr, 10, 64)
+		if err != nil {
+			toKill = append(toKill, workflowIDStr)
+			continue
+		}
+		wf, err := s.store.WorkflowLoad(workflowID)
+		if err != nil || wf.Started > 0 {
+			toKill = append(toKill, workflowIDStr)
+			if wf != nil {
+				workflowCache[workflowIDStr] = wf
+			}
+		} else {
+			toRequeue = append(toRequeue, taskByID[workflowIDStr])
+			log.Info().Int64("agent_id", agentID).Int64("workflow_id", workflowID).
+				Msg("release: re-queuing claimed-but-not-started task (#72)")
+		}
+	}
+
+	// Re-queue claimed-but-not-started tasks so another agent can pick them up.
+	if len(toRequeue) > 0 {
+		if err := s.queue.PushAtOnce(c, toRequeue); err != nil {
+			log.Error().Err(err).Msg("release: failed to re-queue claimed tasks — falling back to kill")
+			for _, t := range toRequeue {
+				toKill = append(toKill, t.ID)
+			}
+		}
+	}
+
+	// Kill tasks that had actually started executing.
+	if err := s.queue.ErrorAtOnce(c, toKill, queue.ErrCancel); err != nil {
 		log.Error().Err(err).Msg("failed to release agent tasks from queue")
 	}
 
 	// Update pipeline database — mirror the completion logic from rpc.Done()
-	// so the pipeline reaches a terminal state and GitHub gets notified (#4)
-	for _, workflowIDStr := range orphaned {
+	// so the pipeline reaches a terminal state and GitHub gets notified (#4).
+	// Only kill DB records for tasks that were actually running.
+	for _, workflowIDStr := range toKill {
 		workflowID, err := strconv.ParseInt(workflowIDStr, 10, 64)
 		if err != nil {
 			continue
 		}
 
-		workflow, err := s.store.WorkflowLoad(workflowID)
-		if err != nil {
-			log.Error().Err(err).Int64("workflow_id", workflowID).
-				Msg("release: failed to load workflow")
-			continue
+		// Use cached workflow from partition step if available.
+		workflow, ok := workflowCache[workflowIDStr]
+		if !ok {
+			workflow, err = s.store.WorkflowLoad(workflowID)
+			if err != nil {
+				log.Error().Err(err).Int64("workflow_id", workflowID).
+					Msg("release: failed to load workflow")
+				continue
+			}
 		}
 
 		// Load children (steps) so WorkflowStatus can evaluate them


### PR DESCRIPTION
A task assigned to a disconnecting agent but never started (workflow.Started == 0) is now re-queued via PushAtOnce instead of killed. Incident: scaler version-bump pipeline 1723 killed in 4s with started=0 — caught in agent 14450's disconnect sweep despite never being dispatched. Adds TestReleaseAgentTasks_RequeueClaimed.