### PR TITLE
fix: split pts-build into 3 workflow files (#75 follow-up)

### DIFF
--- a/.woodpecker/pts-build-cleanup.yaml
+++ b/.woodpecker/pts-build-cleanup.yaml
@@ -1,0 +1,27 @@
+when:
+  - event: push
+    branch: main
+    status: [success, failure]
+
+labels:
+  platform: linux
+  backend: local
+
+depends_on: [pts-build-compile]
+
+steps:
+  - name: stop-vm
+    image: bash
+    commands:
+      - scripts/woodpecker/pts-cleanup.sh
+
+  - name: notify
+    image: bash
+    environment:
+      SLACK_WEBHOOK_URL:
+        from_secret: slack_webhook_url
+    commands:
+      - scripts/woodpecker/pts-notify.sh
+    when:
+      - status: [success, failure]
+    depends_on: [stop-vm]

--- a/.woodpecker/pts-build-compile.yaml
+++ b/.woodpecker/pts-build-compile.yaml
@@ -1,0 +1,19 @@
+when:
+  - event: push
+    branch: main
+
+labels:
+  agent: pts-build
+
+depends_on: [pts-build]
+
+steps:
+  - name: build
+    image: bash
+    environment:
+      DEPLOY_SSH_KEY:
+        from_secret: deploy_ssh_key
+      GH_TOKEN:
+        from_secret: gh_token
+    commands:
+      - scripts/woodpecker/pts-build.sh

--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -2,63 +2,17 @@ when:
   - event: push
     branch: main
 
-# Workflow 1: start pentest-dev-vm + register pts-build agent (#74)
-# Runs on d3ci42-local (lightweight — gcloud start + wait for agent registration).
-# Sets a TTL label on the VM as a safety net for the cleanup workflow.
-- name: wake-pentest-dev
-  labels:
-    platform: linux
-    backend: local
-  steps:
-    - name: wake
-      image: bash
-      environment:
-        PTS_BUILD_SSH_KEY:
-          from_secret: pts_build_ssh_key
-        WOODPECKER_API_TOKEN:
-          from_secret: woodpecker_api_token
-      commands:
-        - scripts/woodpecker/pts-wake.sh
+labels:
+  platform: linux
+  backend: local
 
-# Workflow 2: build on pentest-dev-vm natively — no SSH indirection (#74)
-# The queue holds this until the pts-build agent registers (see wake above).
-# git-lfs is in the Packer image so the standard clone step works.
-- name: build-and-push
-  labels:
-    agent: pts-build
-  depends_on: [wake-pentest-dev]
-  steps:
-    - name: build
-      image: bash
-      environment:
-        DEPLOY_SSH_KEY:
-          from_secret: deploy_ssh_key
-        GH_TOKEN:
-          from_secret: gh_token
-      commands:
-        - scripts/woodpecker/pts-build.sh
-
-# Workflow 3: stop pentest-dev-vm + notify (always runs — success or failure)
-- name: cleanup
-  labels:
-    platform: linux
-    backend: local
-  depends_on: [build-and-push]
-  when:
-    - status: [success, failure]
-  steps:
-    - name: stop-vm
-      image: bash
-      commands:
-        - scripts/woodpecker/pts-cleanup.sh
-
-    - name: notify
-      image: bash
-      environment:
-        SLACK_WEBHOOK_URL:
-          from_secret: slack_webhook_url
-      commands:
-        - scripts/woodpecker/pts-notify.sh
-      when:
-        - status: [success, failure]
-      depends_on: [stop-vm]
+steps:
+  - name: wake
+    image: bash
+    environment:
+      PTS_BUILD_SSH_KEY:
+        from_secret: pts_build_ssh_key
+      WOODPECKER_API_TOKEN:
+        from_secret: woodpecker_api_token
+    commands:
+      - scripts/woodpecker/pts-wake.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: split pts-build into 3 separate workflow files — Woodpecker v3 requires one file per workflow; multi-workflow list syntax in a single YAML is not supported. `pts-build.yaml` (wake), `pts-build-compile.yaml` (pentest-dev native build), `pts-build-cleanup.yaml` (stop VM + notify).
+
 - feat: two-workflow pts-build — pentest-dev-vm runs as native Woodpecker agent (#74). Replaces SSH-orchestration-from-d3ci42 with a proper two-workflow pipeline: (1) `wake-pentest-dev` (backend:local on d3ci42) starts pentest-dev-vm, sets a TTL label safety net, starts woodpecker-agent with `agent=pts-build` label, polls until registered; (2) `build-and-push` (agent=pts-build on pentest-dev-vm) runs natively — clone step, GCS cache restore, pnpm build, go build, rsync to d3ci42, health check, GH Release; (3) `cleanup` (backend:local on d3ci42) stops VM and removes TTL label (always runs). Removes all SSH orchestration from pts-build.sh. pts-build.sh reduced from ~280 to ~140 lines.
 
 - fix: re-queue claimed-but-not-started tasks on agent disconnect instead of killing them (#72). `ReleaseAgentTasks` now checks `workflow.Started` before acting: tasks with `Started == 0` are re-queued via `PushAtOnce` (agent claimed but never began executing — safe for another agent to pick up); tasks with `Started > 0` are killed as before. Incident 2026-05-05: scaler version-bump pipeline 1723 was killed in 4s with `started=0` because it was in the queue when agent 14450 disconnected. The bug was introduced when we built `ReleaseAgentTasks` in fork#3 — the fast-release path correctly replaced the 15-min TaskTimeout but didn't distinguish claimed vs running. Falls back to kill if re-queue fails or workflow can't be loaded.


### PR DESCRIPTION
Woodpecker v3 requires one workflow per file. Split the multi-workflow list into pts-build.yaml (wake), pts-build-compile.yaml (pentest-dev build), pts-build-cleanup.yaml (stop VM + notify). `depends_on` references workflow names across files.