### PR TITLE
fix: decouple woodpecker-server deploy from pts-build pipeline (#74 follow-up)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -88,3 +88,5 @@
 - Fix gcppubsub publish "context canceled" — use background context for async Pub/Sub delivery (#667)
 - Fix queue API 500 on missing agent — use placeholder name instead of erroring, prevents cascade cancellation of healthy pipelines (ci-infrastructure#678)
 
+
+- fix: decouple woodpecker-server deploy from Woodpecker pipeline — pts-build.sh now uploads binary to GCS and writes a pending-deploy marker; woodpecker-deploy.sh on d3ci42 (systemd timer, every 30s) handles download, SHA256 verify, symlink, restart, 90s health check with rollback, and Slack alerts. pts-cleanup.sh no longer touches d3ci42 at all. Fixes the self-kill problem where pts-build-compile caused its own pipeline to be killed by restarting the server it was connected to.

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -1,32 +1,22 @@
 #!/usr/bin/env bash
-# pts-build.sh — compile woodpecker and deploy to d3ci42.
+# pts-build.sh — compile woodpecker and publish to GCS for deployment.
 # Runs natively on pentest-dev-vm via the pts-build Woodpecker agent (#74).
-# Workspace is already checked out by Woodpecker's clone step.
+# Does NOT touch d3ci42 directly — binary is placed in GCS and a pending-deploy
+# marker is written. woodpecker-deploy.sh on d3ci42 picks it up via systemd timer.
 #
-# Prerequisites on pentest-dev-vm (Packer image):
-#   - /usr/local/go/bin/go + gcc (CGO for go-sqlite3)
-#   - node + pnpm (web UI)
-#   - gsutil (GCS build cache)
-#
-# Secrets:
-#   DEPLOY_SSH_KEY — SSH key for pentest-dev → d3ci42 deploy
-#   GH_TOKEN       — GitHub PAT for tagging + release
+# Secrets: GH_TOKEN (tagging + release)
 set -euo pipefail
-
-SERVER_HOST="159.203.159.69"
-RELEASES_DIR="/opt/woodpecker/server/releases"
-CURRENT_LINK="/opt/woodpecker/server/current"
-KEEP_RELEASES=3
 
 SHA_SHORT=$(echo "${CI_COMMIT_SHA:-$(git rev-parse HEAD)}" | cut -c1-8)
 VERSION="v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}"
 COMMIT_SHA="${CI_COMMIT_SHA:-$(git rev-parse HEAD)}"
+BUILD_CACHE_BUCKET="gs://ci-runners-de-build-cache"
+DEPLOY_BUCKET="${BUILD_CACHE_BUCKET}/woodpecker-deploy"
 
 echo "==> pts-build: ${VERSION} (${SHA_SHORT})"
 
-# ── GCS build cache (#851) ──
+# ── GCS build cache ──
 export PATH="/usr/local/go/bin:$PATH"
-BUILD_CACHE_BUCKET="gs://ci-runners-de-build-cache"
 GOCACHE="${HOME}/.cache/go-build"
 GOMODCACHE="${HOME}/go/pkg/mod"
 mkdir -p "${GOCACHE}" "${GOMODCACHE}"
@@ -37,114 +27,48 @@ gsutil -m -q rsync -r "${BUILD_CACHE_BUCKET}/go-build/" "${GOCACHE}/" 2>/dev/nul
 gsutil -m -q rsync -r "${BUILD_CACHE_BUCKET}/go-mod/" "${GOMODCACHE}/" 2>/dev/null && \
     echo "    go-mod: $(du -sh "${GOMODCACHE}" | cut -f1)" || echo "    go-mod: cold"
 
-# ── Build web UI ──
-echo ""
-echo "==> Building web UI..."
+# ── Web UI ──
+echo ""; echo "==> Building web UI..."
 cd web && pnpm install --frozen-lockfile >/dev/null 2>&1 && pnpm build >/dev/null 2>&1
 echo "    $(ls dist/ | wc -l) files"
 cd ..
 
-# ── Compile binaries ──
+# ── Compile ──
 mkdir -p bin
-
-echo ""
-echo "==> Compiling woodpecker-server (CGO=1)..."
+echo ""; echo "==> Compiling woodpecker-server (CGO=1)..."
 CGO_ENABLED=1 go build \
     -ldflags "-s -w -X go.woodpecker-ci.org/woodpecker/v3/version.Version=${VERSION}" \
     -o bin/woodpecker-server ./cmd/server
 echo "    $(du -h bin/woodpecker-server | cut -f1)"
 
-echo ""
-echo "==> Compiling woodpecker-agent (CGO=0)..."
+echo ""; echo "==> Compiling woodpecker-agent (CGO=0)..."
 CGO_ENABLED=0 go build \
     -ldflags "-s -w -X go.woodpecker-ci.org/woodpecker/v3/version.Version=${VERSION}" \
     -o bin/woodpecker-agent ./cmd/agent
 echo "    $(du -h bin/woodpecker-agent | cut -f1)"
 
-echo ""
-echo "==> Saving GCS build cache..."
+echo ""; echo "==> Saving GCS build cache..."
 gsutil -m -q rsync -r "${GOCACHE}/" "${BUILD_CACHE_BUCKET}/go-build/" 2>/dev/null && \
     echo "    go-build saved" || echo "    ⚠️  go-build save failed (non-fatal)"
 gsutil -m -q rsync -r "${GOMODCACHE}/" "${BUILD_CACHE_BUCKET}/go-mod/" 2>/dev/null && \
     echo "    go-mod saved" || echo "    ⚠️  go-mod save failed (non-fatal)"
 
-# ── SSH setup for d3ci42 deploy ──
-SSH_KEY=".deploy-ssh/id_ed25519"
-mkdir -p .deploy-ssh
-echo "$DEPLOY_SSH_KEY" > "$SSH_KEY"
-printf '\n' >> "$SSH_KEY"
-chmod 600 "$SSH_KEY"
-SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
-ssh_cmd() { $SSH "root@${SERVER_HOST}" "$@"; }
+# ── Upload binary to GCS for deployment ──
+# woodpecker-deploy.sh on d3ci42 polls DEPLOY_BUCKET/pending and picks this up.
+echo ""; echo "==> Uploading ${VERSION} to GCS for deployment..."
+SHA256=$(sha256sum bin/woodpecker-server | awk '{print $1}')
+echo "${SHA256}" > bin/woodpecker-server.sha256
 
-# ── Deploy server to d3ci42 ──
-echo ""
-echo "==> Deploying ${VERSION} to ${SERVER_HOST}..."
-PREVIOUS=$(ssh_cmd "readlink -f ${CURRENT_LINK} 2>/dev/null | xargs basename 2>/dev/null || echo ''" || echo "")
-echo "    Previous: ${PREVIOUS:-<none>}"
+gsutil -q cp bin/woodpecker-server "${DEPLOY_BUCKET}/${VERSION}/woodpecker-server"
+gsutil -q cp bin/woodpecker-server.sha256 "${DEPLOY_BUCKET}/${VERSION}/woodpecker-server.sha256"
 
-ssh_cmd "mkdir -p ${RELEASES_DIR}/${VERSION}"
-rsync -az --checksum \
-    -e "ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR" \
-    bin/woodpecker-server "root@${SERVER_HOST}:${RELEASES_DIR}/${VERSION}/woodpecker-server"
-ssh_cmd "chmod 755 ${RELEASES_DIR}/${VERSION}/woodpecker-server"
+# Write pending-deploy marker last — woodpecker-deploy.sh polls for this
+printf '%s\n%s\n%s' "${VERSION}" "${COMMIT_SHA}" "${CI_PIPELINE_NUMBER:-0}" | \
+    gsutil -q cp - "${DEPLOY_BUCKET}/pending"
+echo "    Binary and pending marker written: ${DEPLOY_BUCKET}/${VERSION}/"
+echo "    SHA256: ${SHA256}"
 
-LOCAL_SHA=$(sha256sum bin/woodpecker-server | awk '{print $1}')
-REMOTE_SHA=$(ssh_cmd "sha256sum ${RELEASES_DIR}/${VERSION}/woodpecker-server | awk '{print \$1}'")
-if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
-    echo "ERROR: checksum mismatch after rsync"
-    exit 1
-fi
-echo "    checksum verified: ${LOCAL_SHA:0:16}..."
-
-ssh_cmd "
-    ln -sfn ${RELEASES_DIR}/${VERSION} ${CURRENT_LINK}
-    systemctl daemon-reload 2>/dev/null || true
-    systemctl restart woodpecker-server
-"
-
-# ── Health check (60s budget) ──
-echo ""
-echo "==> Health check..."
-HEALTHY=0
-for i in 0 1 2 3 4; do
-    T=$((i * 15))
-    RESPONSE=$(ssh_cmd "curl -sf --max-time 5 http://localhost:8000/healthz 2>/dev/null || echo ''" || echo "")
-    if [ -z "$RESPONSE" ]; then
-        echo "  t=${T}s: <unreachable>"
-    else
-        VERSION_SERVED=$(echo "$RESPONSE" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("version","?"))' 2>/dev/null || echo "?")
-        echo "  t=${T}s: version=${VERSION_SERVED}"
-        if echo "$RESPONSE" | grep -q '"status":"ok"'; then
-            HEALTHY=1
-            break
-        fi
-    fi
-    [ "$i" -lt 4 ] && sleep 15
-done
-
-if [ "$HEALTHY" -ne 1 ]; then
-    echo "❌ Health check failed — rolling back to ${PREVIOUS:-<none>}"
-    if [ -n "$PREVIOUS" ] && ssh_cmd "test -d ${RELEASES_DIR}/${PREVIOUS}"; then
-        ssh_cmd "
-            ln -sfn ${RELEASES_DIR}/${PREVIOUS} ${CURRENT_LINK}
-            systemctl restart woodpecker-server
-        "
-        echo "⚠️  Rolled back to ${PREVIOUS}"
-    fi
-    exit 1
-fi
-
-ssh_cmd "
-    find ${RELEASES_DIR} -maxdepth 1 -mindepth 1 -type d | sort -r | tail -n +$((KEEP_RELEASES + 1)) | while read -r dir; do
-        current=\$(readlink -f ${CURRENT_LINK} 2>/dev/null || echo '')
-        [ \"\$dir\" != \"\$current\" ] && rm -rf \"\$dir\" && echo \"Pruned: \$dir\"
-    done
-" 2>/dev/null || true
-
-echo "✅ ${VERSION} deployed to ${SERVER_HOST}"
-
-# ── Phase 3: GitHub Release + binary assets + builder VM wake ──
+# ── GitHub Release + binary assets ──
 REPO_FULL="Peregrine-Technology-Systems/woodpecker"
 GH_API="https://api.github.com"
 GH_AUTH="Authorization: Bearer ${GH_TOKEN:-}"
@@ -154,8 +78,7 @@ if [ -z "${GH_TOKEN:-}" ]; then
     exit 0
 fi
 
-echo ""
-echo "==> Phase 3a: tag fork at build commit"
+echo ""; echo "==> Phase 3a: tag fork at build commit"
 if curl -sS -H "${GH_AUTH}" "${GH_API}/repos/${REPO_FULL}/git/refs/tags/${VERSION}" | grep -q '"ref"'; then
     echo "    Tag ${VERSION} already exists; reusing"
 else
@@ -166,9 +89,8 @@ else
         { echo "    ⚠️  Tag failed: $(echo "${TAG_RESP}" | head -c 100)"; exit 0; }
 fi
 
-echo ""
-echo "==> Phase 3b: create GitHub Release"
-RELEASE_BODY="Automated release from pts-build pipeline ${CI_PIPELINE_NUMBER:-?}.\n\nBinaries attached as release assets. Deployed to d3ci42 via native rsync (#57, #74)."
+echo ""; echo "==> Phase 3b: create GitHub Release"
+RELEASE_BODY="Automated release from pts-build pipeline ${CI_PIPELINE_NUMBER:-?}.\n\nBinaries attached as release assets. Deployed to d3ci42 via GCS pending-deploy pattern (woodpecker#74)."
 RELEASE_ID=$(curl -sS -H "${GH_AUTH}" "${GH_API}/repos/${REPO_FULL}/releases/tags/${VERSION}" | \
     python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("id","") if isinstance(d,dict) else "")' 2>/dev/null || echo "")
 
@@ -199,8 +121,7 @@ upload_asset() {
 upload_asset "woodpecker-server-linux-amd64" "bin/woodpecker-server"
 upload_asset "woodpecker-agent-linux-amd64"  "bin/woodpecker-agent"
 
-echo ""
-echo "==> Phase 3c: wake ci-image-builder"
+echo ""; echo "==> Phase 3c: wake ci-image-builder"
 BUILDER_PROJECT="ci-runners-de"
 BUILDER_ZONE="us-central1-a"
 BUILDER_VM="ci-image-builder"
@@ -212,13 +133,13 @@ cat > "${JOB_FILE}" << JOB
 {"request_id":"${REQUEST_ID}","wp_version":"${VERSION}","scaler_version":"","triggered_by":"woodpecker-pts-build-${CI_PIPELINE_NUMBER:-?}","created_at":"${NOW_ISO}"}
 JOB
 if gsutil -q cp "${JOB_FILE}" "gs://${BUILDER_BUCKET}/jobs/${REQUEST_ID}.json" 2>/dev/null; then
-    echo "    Wrote job: ${REQUEST_ID}"
+    echo "    Wrote builder job: ${REQUEST_ID}"
     gcloud --quiet compute instances start "${BUILDER_VM}" --zone="${BUILDER_ZONE}" --project="${BUILDER_PROJECT}" 2>/dev/null && \
-        echo "    Started ${BUILDER_VM}" || echo "    ⚠️  Could not start builder VM — job queued"
+        echo "    Started ${BUILDER_VM}" || echo "    ⚠️  Could not start builder VM"
 else
-    echo "    ⚠️  Could not write job file — non-blocking"
+    echo "    ⚠️  Could not write builder job — non-blocking"
 fi
 rm -f "${JOB_FILE}"
 
-echo ""
-echo "==> pts-build complete: ${VERSION}"
+echo ""; echo "==> pts-build complete: ${VERSION}"
+echo "    Deployment will complete within 2 minutes via woodpecker-deploy.sh on d3ci42."

--- a/scripts/woodpecker/pts-cleanup.sh
+++ b/scripts/woodpecker/pts-cleanup.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# pts-cleanup.sh — stop pentest-dev-vm and remove TTL label.
-# Runs on d3ci42-local (backend: local). Always runs — success or failure.
+# pts-cleanup.sh — stop pentest-dev-vm and remove TTL labels.
+# Runs on d3ci42-local after pts-build-compile completes (success or failure).
+# Deploy of woodpecker-server is handled separately by woodpecker-deploy.sh
+# via systemd timer — NOT here. Decoupled to avoid the self-kill problem (#74).
 set -euo pipefail
 
 PENTEST_PROJECT="peregrine-pentest-dev"

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# woodpecker-deploy.sh — standalone woodpecker-server deploy script.
+# Runs on d3ci42 as a systemd timer (every 30s). Completely independent of
+# Woodpecker pipelines — safe to run while woodpecker-server is being restarted.
+#
+# Flow:
+#   1. Check GCS for pending-deploy marker; exit 0 if absent
+#   2. Read version, download binary, verify SHA256
+#   3. Stage release: mkdir, rsync, chmod, symlink (atomic)
+#   4. Restart woodpecker-server via systemctl
+#   5. 90s health check — poll /healthz until version matches or timeout
+#   6. On failure: rollback symlink + restart, Slack alert, remove pending marker
+#   7. On success: prune old releases, remove pending marker, Slack success
+#
+# Alarms: Slack message on failure or health-check timeout.
+# Idempotent: if pending marker is absent, exits immediately (no-op).
+set -euo pipefail
+
+DEPLOY_BUCKET="gs://ci-runners-de-build-cache/woodpecker-deploy"
+RELEASES_DIR="/opt/woodpecker/server/releases"
+CURRENT_LINK="/opt/woodpecker/server/current"
+KEEP_RELEASES=3
+HEALTH_URL="http://localhost:8000/healthz"
+HEALTH_BUDGET=90  # seconds
+LOCK_FILE="/tmp/woodpecker-deploy.lock"
+
+# ── Secrets ──
+source /etc/woodpecker/secrets.env 2>/dev/null || true
+SLACK_URL="${SLACK_WEBHOOK_URL:-}"
+
+slack() {
+    local emoji="$1" msg="$2"
+    [ -z "${SLACK_URL}" ] && return 0
+    curl -sf -X POST "${SLACK_URL}" -H "Content-Type: application/json" \
+        -d "{\"text\":\"${emoji} *woodpecker-deploy* ${msg}\"}" >/dev/null 2>&1 || true
+}
+
+# ── Exclusive lock — prevent concurrent runs ──
+exec 9>"${LOCK_FILE}"
+if ! flock -n 9; then
+    echo "Another woodpecker-deploy.sh is running — exiting"
+    exit 0
+fi
+
+# ── Check for pending deploy ──
+PENDING_CONTENT=$(gsutil -q cat "${DEPLOY_BUCKET}/pending" 2>/dev/null || echo "")
+if [ -z "${PENDING_CONTENT}" ]; then
+    exit 0  # nothing to deploy
+fi
+
+VERSION=$(echo "${PENDING_CONTENT}" | head -1)
+COMMIT_SHA=$(echo "${PENDING_CONTENT}" | sed -n '2p')
+PIPELINE_NUM=$(echo "${PENDING_CONTENT}" | sed -n '3p')
+
+echo "$(date -u +%FT%TZ) woodpecker-deploy: deploying ${VERSION} (pipeline #${PIPELINE_NUM})"
+
+# ── Capture previous release for rollback ──
+PREVIOUS=$(readlink -f "${CURRENT_LINK}" 2>/dev/null | xargs basename 2>/dev/null || echo "")
+echo "    Previous: ${PREVIOUS:-<none>}"
+
+# ── Download and verify binary ──
+STAGE_DIR="/tmp/woodpecker-stage-${VERSION}"
+rm -rf "${STAGE_DIR}"
+mkdir -p "${STAGE_DIR}"
+
+echo "    Downloading ${VERSION} from GCS..."
+if ! gsutil -q cp "${DEPLOY_BUCKET}/${VERSION}/woodpecker-server" "${STAGE_DIR}/woodpecker-server" 2>/dev/null; then
+    echo "ERROR: binary not found in GCS: ${DEPLOY_BUCKET}/${VERSION}/woodpecker-server"
+    slack ":x:" "deploy ${VERSION} FAILED — binary not found in GCS. Pipeline #${PIPELINE_NUM}."
+    gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
+    rm -rf "${STAGE_DIR}"
+    exit 1
+fi
+
+EXPECTED_SHA=$(gsutil -q cat "${DEPLOY_BUCKET}/${VERSION}/woodpecker-server.sha256" 2>/dev/null || echo "")
+ACTUAL_SHA=$(sha256sum "${STAGE_DIR}/woodpecker-server" | awk '{print $1}')
+if [ -z "${EXPECTED_SHA}" ] || [ "${EXPECTED_SHA}" != "${ACTUAL_SHA}" ]; then
+    echo "ERROR: SHA256 mismatch — expected=${EXPECTED_SHA:-missing} actual=${ACTUAL_SHA}"
+    slack ":x:" "deploy ${VERSION} FAILED — SHA256 mismatch. Expected: \`${EXPECTED_SHA:0:12}...\` Got: \`${ACTUAL_SHA:0:12}...\`. Pipeline #${PIPELINE_NUM}."
+    gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
+    rm -rf "${STAGE_DIR}"
+    exit 1
+fi
+echo "    SHA256 verified: ${ACTUAL_SHA:0:16}..."
+
+# ── Stage release ──
+mkdir -p "${RELEASES_DIR}/${VERSION}"
+cp "${STAGE_DIR}/woodpecker-server" "${RELEASES_DIR}/${VERSION}/woodpecker-server"
+chmod 755 "${RELEASES_DIR}/${VERSION}/woodpecker-server"
+rm -rf "${STAGE_DIR}"
+
+# Atomic symlink swap
+ln -sfn "${RELEASES_DIR}/${VERSION}" "${CURRENT_LINK}"
+echo "    Symlink: ${CURRENT_LINK} → ${RELEASES_DIR}/${VERSION}"
+
+# ── Restart woodpecker-server ──
+echo "    Restarting woodpecker-server..."
+systemctl restart woodpecker-server
+
+# ── Health check (90s budget) ──
+echo "    Health check (${HEALTH_BUDGET}s budget)..."
+HEALTHY=0
+DEADLINE=$(( $(date +%s) + HEALTH_BUDGET ))
+while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+    RESPONSE=$(curl -sf --max-time 3 "${HEALTH_URL}" 2>/dev/null || echo "")
+    if [ -n "${RESPONSE}" ]; then
+        STATUS=$(echo "${RESPONSE}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status",""))' 2>/dev/null || echo "")
+        VERSION_SERVED=$(echo "${RESPONSE}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("version",""))' 2>/dev/null || echo "")
+        echo "    healthz: status=${STATUS} version=${VERSION_SERVED}"
+        if [ "${STATUS}" = "ok" ] && [ "${VERSION_SERVED}" = "${VERSION}" ]; then
+            HEALTHY=1
+            break
+        fi
+    fi
+    sleep 5
+done
+
+if [ "${HEALTHY}" -ne 1 ]; then
+    echo "ERROR: health check timed out after ${HEALTH_BUDGET}s — rolling back to ${PREVIOUS:-<none>}"
+    # Rollback
+    if [ -n "${PREVIOUS}" ] && [ -d "${RELEASES_DIR}/${PREVIOUS}" ]; then
+        ln -sfn "${RELEASES_DIR}/${PREVIOUS}" "${CURRENT_LINK}"
+        systemctl restart woodpecker-server
+        sleep 5
+        ROLLBACK_OK=$(curl -sf --max-time 5 "${HEALTH_URL}" 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status",""))' 2>/dev/null || echo "")
+        if [ "${ROLLBACK_OK}" = "ok" ]; then
+            echo "    Rolled back to ${PREVIOUS} — server healthy"
+            slack ":rotating_light:" "deploy ${VERSION} FAILED (health-check timeout). Rolled back to \`${PREVIOUS}\`. Server healthy. Pipeline #${PIPELINE_NUM}. Manual investigation required."
+        else
+            slack ":sos:" "deploy ${VERSION} FAILED + rollback FAILED. woodpecker-server may be DOWN. Pipeline #${PIPELINE_NUM}. Immediate attention required."
+        fi
+    else
+        slack ":sos:" "deploy ${VERSION} FAILED (health-check timeout) + no rollback target. woodpecker-server may be DOWN. Pipeline #${PIPELINE_NUM}. Immediate attention required."
+    fi
+    gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
+    exit 1
+fi
+
+# ── Success ──
+echo "✅ ${VERSION} deployed and healthy"
+
+# Prune old releases (keep KEEP_RELEASES most recent)
+find "${RELEASES_DIR}" -maxdepth 1 -mindepth 1 -type d | sort -r | \
+    tail -n +$(( KEEP_RELEASES + 1 )) | while read -r dir; do
+    current=$(readlink -f "${CURRENT_LINK}" 2>/dev/null || echo "")
+    [ "${dir}" != "${current}" ] && rm -rf "${dir}" && echo "    Pruned: ${dir}"
+done
+
+# Remove pending marker
+gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
+
+slack ":white_check_mark:" "woodpecker-server \`${VERSION}\` deployed to d3ci42. Pipeline #${PIPELINE_NUM}. Commit: \`${COMMIT_SHA:0:8}\`."
+
+echo "$(date -u +%FT%TZ) woodpecker-deploy: ${VERSION} complete"


### PR DESCRIPTION
pts-build.sh now uploads binary to GCS and writes a pending-deploy marker — never touches d3ci42 directly. New woodpecker-deploy.sh runs on d3ci42 as a systemd timer (every 30s): download, SHA256 verify, symlink, restart, 90s health check with rollback, Slack alerts. Eliminates the self-kill problem where the compile step was restarting the server its agent was connected to.