### PR TITLE
fix: inject WOODPECKER_AGENT_SECRET via secret in pts-build wake step

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -13,5 +13,7 @@ steps:
         from_secret: pts_build_ssh_key
       WOODPECKER_API_TOKEN:
         from_secret: woodpecker_api_token
+      WOODPECKER_AGENT_SECRET:
+        from_secret: woodpecker_agent_secret
     commands:
       - scripts/woodpecker/pts-wake.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh reads WOODPECKER_AGENT_SECRET from Woodpecker secret instead of /etc/woodpecker/secrets.env — file read failed in local backend context (exit 2), pentest-dev agent never registered, pts-build-compile queued indefinitely. Secret now injected via from_secret.
+
 - fix: remove backend:local from pts-ci.yaml and pts-build.yaml (#77). backend:local routes to the d3ci42-local agent — wrong for every pipeline. pts-ci runs on normal GCP agents; pts-build wake step uses platform:linux,backend:local only for the d3ci42-local gcloud orchestration step (retained in pts-build.yaml).
 
 - fix: split pts-build into 3 separate workflow files — Woodpecker v3 requires one file per workflow; multi-workflow list syntax in a single YAML is not supported. `pts-build.yaml` (wake), `pts-build-compile.yaml` (pentest-dev native build), `pts-build-cleanup.yaml` (stop VM + notify).

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -47,8 +47,8 @@ for i in $(seq 1 12); do
     sleep 10
 done
 
-# Read agent secret from local secrets file (we're on d3ci42)
-AGENT_SECRET=$(grep WOODPECKER_AGENT_SECRET /etc/woodpecker/secrets.env | cut -d= -f2-)
+# Agent secret injected as WOODPECKER_AGENT_SECRET env var via Woodpecker secret
+AGENT_SECRET="${WOODPECKER_AGENT_SECRET:?WOODPECKER_AGENT_SECRET must be set}"
 
 # Find the woodpecker-agent binary on pentest-dev
 AGENT_BIN=$($PTS_SSH "root@${PENTEST_IP}" \


### PR DESCRIPTION
pts-wake.sh was reading the agent secret from /etc/woodpecker/secrets.env — file read failed in the local backend step context (exit 2). pentest-dev-vm started but its woodpecker-agent launched unauthenticated, never registered, and pts-build-compile queued forever. Fixed via from_secret injection.