### PR TITLE
fix: auto-install woodpecker-agent on pentest-dev-vm if absent

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -15,5 +15,7 @@ steps:
         from_secret: woodpecker_api_token
       WOODPECKER_AGENT_SECRET:
         from_secret: woodpecker_agent_secret
+      GH_TOKEN:
+        from_secret: gh_token
     commands:
       - scripts/woodpecker/pts-wake.sh

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh auto-installs woodpecker-agent binary on pentest-dev-vm if absent — downloads latest woodpecker-agent-linux-amd64 asset from the GitHub Release. Handles fresh VMs and snapshot restores. Previously exited with hard error if binary not found.
+
 - fix: pts-wake.sh reads WOODPECKER_AGENT_SECRET from Woodpecker secret instead of /etc/woodpecker/secrets.env — file read failed in local backend context (exit 2), pentest-dev agent never registered, pts-build-compile queued indefinitely. Secret now injected via from_secret.
 
 - fix: remove backend:local from pts-ci.yaml and pts-build.yaml (#77). backend:local routes to the d3ci42-local agent — wrong for every pipeline. pts-ci runs on normal GCP agents; pts-build wake step uses platform:linux,backend:local only for the d3ci42-local gcloud orchestration step (retained in pts-build.yaml).

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -50,12 +50,35 @@ done
 # Agent secret injected as WOODPECKER_AGENT_SECRET env var via Woodpecker secret
 AGENT_SECRET="${WOODPECKER_AGENT_SECRET:?WOODPECKER_AGENT_SECRET must be set}"
 
-# Find the woodpecker-agent binary on pentest-dev
+# Ensure woodpecker-agent binary exists on pentest-dev.
+# If absent, download the latest published asset from the GitHub Release.
+# This handles fresh VMs and snapshot restores cleanly.
 AGENT_BIN=$($PTS_SSH "root@${PENTEST_IP}" \
     "ls /opt/woodpecker/woodpecker-agent-* 2>/dev/null | sort -V | tail -1 || echo ''")
 if [ -z "${AGENT_BIN}" ]; then
-    echo "ERROR: no woodpecker-agent binary found on ${PENTEST_VM}"
-    exit 1
+    echo "==> No agent binary on ${PENTEST_VM} — downloading from latest GitHub Release..."
+    LATEST_TAG=$(curl -sf -H "Authorization: Bearer ${GH_TOKEN:-}" \
+        "https://api.github.com/repos/Peregrine-Technology-Systems/woodpecker/releases/latest" | \
+        python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["tag_name"])' 2>/dev/null || echo "")
+    if [ -z "$LATEST_TAG" ]; then
+        echo "ERROR: could not determine latest release tag"
+        exit 1
+    fi
+    AGENT_URL=$(curl -sf -H "Authorization: Bearer ${GH_TOKEN:-}" \
+        "https://api.github.com/repos/Peregrine-Technology-Systems/woodpecker/releases/latest" | \
+        python3 -c 'import json,sys; d=json.load(sys.stdin); print(next((a["browser_download_url"] for a in d["assets"] if a["name"]=="woodpecker-agent-linux-amd64"), ""))' 2>/dev/null || echo "")
+    if [ -z "$AGENT_URL" ]; then
+        echo "ERROR: woodpecker-agent-linux-amd64 asset not found in release ${LATEST_TAG}"
+        exit 1
+    fi
+    AGENT_BIN="/opt/woodpecker/woodpecker-agent-${LATEST_TAG}"
+    $PTS_SSH "root@${PENTEST_IP}" "
+        mkdir -p /opt/woodpecker
+        curl -sfL -H 'Authorization: Bearer ${GH_TOKEN:-}' '${AGENT_URL}' \
+            -o '${AGENT_BIN}' && chmod +x '${AGENT_BIN}'
+        echo 'Downloaded: ${AGENT_BIN}'
+    "
+    echo "    downloaded: ${AGENT_BIN}"
 fi
 echo "    agent binary: ${AGENT_BIN}"
 


### PR DESCRIPTION
pts-wake.sh exited 1 when no agent binary on pentest-dev-vm (fresh VM / snapshot restore). Now downloads `woodpecker-agent-linux-amd64` from the latest GitHub Release automatically. Adds GH_TOKEN to wake step env.