### PR TITLE
fix: pts-build.sh caches compiled agent binary on pentest-dev-vm for next wake

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-build.sh leaves compiled woodpecker-agent at /opt/woodpecker/woodpecker-agent-${VERSION} on pentest-dev-vm after each compile. Next wake finds it immediately — no GitHub Release download needed. Ensures agent/server version parity across builds.
+
 - fix: pts-wake.sh auto-installs woodpecker-agent binary on pentest-dev-vm if absent — downloads latest woodpecker-agent-linux-amd64 asset from the GitHub Release. Handles fresh VMs and snapshot restores. Previously exited with hard error if binary not found.
 
 - fix: pts-wake.sh reads WOODPECKER_AGENT_SECRET from Woodpecker secret instead of /etc/woodpecker/secrets.env — file read failed in local backend context (exit 2), pentest-dev agent never registered, pts-build-compile queued indefinitely. Secret now injected via from_secret.

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -47,6 +47,13 @@ CGO_ENABLED=0 go build \
     -o bin/woodpecker-agent ./cmd/agent
 echo "    $(du -h bin/woodpecker-agent | cut -f1)"
 
+# Leave agent binary in place for the next pts-wake run — avoids the GitHub
+# Release download on every cold-start. The wake step finds this exact version
+# and uses it as the pts-build CI agent, ensuring agent/server version parity.
+cp bin/woodpecker-agent "/opt/woodpecker/woodpecker-agent-${VERSION}"
+chmod +x "/opt/woodpecker/woodpecker-agent-${VERSION}"
+echo "    agent binary cached: /opt/woodpecker/woodpecker-agent-${VERSION}"
+
 echo ""; echo "==> Saving GCS build cache..."
 gsutil -m -q rsync -r "${GOCACHE}/" "${BUILD_CACHE_BUCKET}/go-build/" 2>/dev/null && \
     echo "    go-build saved" || echo "    ⚠️  go-build save failed (non-fatal)"


### PR DESCRIPTION
After compiling `woodpecker-agent`, copies it to `/opt/woodpecker/woodpecker-agent-${VERSION}` on pentest-dev-vm. Next pts-wake finds it immediately — no GitHub Release download. Ensures agent/server version parity.