### PR TITLE
fix: guard pts-wake.sh against concurrent pipeline runs

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh guards against concurrent runs — if pentest-dev-vm is already RUNNING (owned by another pipeline), the wake step exits 0 cleanly instead of racing. Multiple main pushes in quick succession (e.g. several PRs merging) each trigger a wake; only the first proceeds, subsequent ones abort with a clear message. Previous behavior: two wakes started the VM simultaneously, both tried to register agents with hostname pentest-dev-vm, SSH races caused exit 255 on one, stuck pts-build-compile tasks in the queue.
+
 - fix: pts-build.sh leaves compiled woodpecker-agent at /opt/woodpecker/woodpecker-agent-${VERSION} on pentest-dev-vm after each compile. Next wake finds it immediately — no GitHub Release download needed. Ensures agent/server version parity across builds.
 
 - fix: pts-wake.sh auto-installs woodpecker-agent binary on pentest-dev-vm if absent — downloads latest woodpecker-agent-linux-amd64 asset from the GitHub Release. Handles fresh VMs and snapshot restores. Previously exited with hard error if binary not found.

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -14,6 +14,24 @@ TTL_MINUTES=60  # generous budget: wake + compile + deploy
 WP_SERVER="d3ci42.peregrinetechsys.net:443"  # Caddy proxies gRPC → port 9000
 VERSION="v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}"
 
+# ── Concurrent-run guard ──
+# If pentest-dev-vm is already RUNNING, another pts-build pipeline is using it.
+# Abort cleanly — the in-flight pipeline will compile and stop the VM.
+# Multiple main pushes in quick succession (e.g. several PRs merging) each
+# trigger their own wake; only the first one should proceed.
+CURRENT_STATUS=$(gcloud compute instances describe "${PENTEST_VM}" \
+    --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+    --format="value(status)" 2>/dev/null || echo "UNKNOWN")
+if [ "${CURRENT_STATUS}" = "RUNNING" ]; then
+    OWNER_PIPELINE=$(gcloud compute instances describe "${PENTEST_VM}" \
+        --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+        --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "unknown")
+    echo "==> ${PENTEST_VM} already RUNNING (owned by pipeline #${OWNER_PIPELINE}) — aborting."
+    echo "    This pipeline (#${CI_PIPELINE_NUMBER:-0}) will be skipped."
+    echo "    The in-flight pipeline will compile and deploy the latest code."
+    exit 0
+fi
+
 echo "==> Starting ${PENTEST_VM} for pts-build ${VERSION}..."
 gcloud compute instances start "${PENTEST_VM}" \
     --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" --quiet


### PR DESCRIPTION
Multiple PRs merging to main cause racing wake steps. Now checks VM status before starting — if already RUNNING, exits 0 cleanly. The in-flight pipeline compiles and deploys; subsequent wakes abort with a clear message. Fixes SSH exit 255 collisions and stuck pts-build-compile queue tasks.