### PR TITLE
fix: set MaxOpenConns=1 for SQLite to complete write queue serialization (#88)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: set MaxOpenConns=1 for SQLite so write queue actually eliminates SQLITE_BUSY — default of 100 connections meant multiple xorm file handles still raced on SQLite's per-connection write lock under burst webhook load (#88)
 - fix: woodpecker-agent exits on persistent auth errors so systemd restarts clean (#77). Runner loop previously retried forever on Unauthenticated/Unknown gRPC errors (token expired, AgentID not found, sql: no rows) — process stayed alive but did no work, workers=0, queue backed up. Now calls log.Fatal() on these, triggering Restart=on-failure. On restart with no agent.conf, agent re-registers fresh.
 
 - fix: pts-wake.sh guards against concurrent runs — if pentest-dev-vm is already RUNNING (owned by another pipeline), the wake step exits 0 cleanly instead of racing. Multiple main pushes in quick succession (e.g. several PRs merging) each trigger a wake; only the first proceeds, subsequent ones abort with a clear message. Previous behavior: two wakes started the VM simultaneously, both tried to register agents with hostname pentest-dev-vm, SSH races caused exit 255 on one, stuck pts-build-compile tasks in the queue.

--- a/server/store/datastore/engine.go
+++ b/server/store/datastore/engine.go
@@ -59,6 +59,12 @@ func NewEngine(opts *store.Opts) (store.Store, error) {
 	s := &storage{engine: engine}
 	if opts.Driver == "sqlite3" {
 		s.wq = newWriteQueue(writeQueueDepth)
+		// Single connection required: the write queue serializes Go-level writes
+		// through one goroutine, but xorm's pool can open multiple SQLite file
+		// handles. SQLite's write lock is per-connection — multiple handles race
+		// on it even with the queue, producing SQLITE_BUSY under burst load (#88).
+		engine.SetMaxOpenConns(1)
+		engine.SetMaxIdleConns(1)
 	}
 	return s, nil
 }


### PR DESCRIPTION
## Problem
Write queue serializes Go goroutines through one drain goroutine but xorm pool defaulted to 100 SQLite connections. SQLite's write lock is per-connection — multiple handles race under burst load producing `table is locked` even with the queue.

## Fix
Force `MaxOpenConns=1` + `MaxIdleConns=1` for SQLite after initializing the write queue. Single goroutine + single connection = true serialization.

## Test
Existing datastore tests pass. The concurrent-write integration test (`TestWriteQueue_ConcurrentWrites_NoLockErrors`) confirms no lock errors with this config.

Closes #88