### PR TITLE
fix: restore backend:local to pts-build.yaml (#96)

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -3,6 +3,7 @@ when:
     branch: main
 
 labels:
+  backend: local
   platform: linux
 
 steps:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: woodpecker-deploy.sh health check was parsing JSON body that does not exist — healthz returns HTTP 204 with empty body, version is in X-Woodpecker-Version response header; cp over running binary fixed with .new + mv pattern; deployed-version pin file written atomically on success (#90)
+
 - fix: set MaxOpenConns=1 for SQLite so write queue actually eliminates SQLITE_BUSY — default of 100 connections meant multiple xorm file handles still raced on SQLite's per-connection write lock under burst webhook load (#88)
 - fix: woodpecker-agent exits on persistent auth errors so systemd restarts clean (#77). Runner loop previously retried forever on Unauthenticated/Unknown gRPC errors (token expired, AgentID not found, sql: no rows) — process stayed alive but did no work, workers=0, queue backed up. Now calls log.Fatal() on these, triggering Restart=on-failure. On restart with no agent.conf, agent re-registers fresh.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: restore `backend: local` to pts-build.yaml — removed incorrectly during backend:local sweep; pts-build is the only legitimate use and must run on d3ci42-local (#96)
 - fix: woodpecker-deploy.sh health check was parsing JSON body that does not exist — healthz returns HTTP 204 with empty body, version is in X-Woodpecker-Version response header; cp over running binary fixed with .new + mv pattern; deployed-version pin file written atomically on success (#90)
 
 - fix: set MaxOpenConns=1 for SQLite so write queue actually eliminates SQLITE_BUSY — default of 100 connections meant multiple xorm file handles still raced on SQLite's per-connection write lock under burst webhook load (#88)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,10 +198,30 @@ Heavy concurrent write load caused the server to freeze. The write queue (#55) e
 
 ---
 
+## JWT Secret and API Token Lifecycle
+
+Woodpecker signs all user tokens and agent sessions with a JWT secret (`WOODPECKER_JWT_SECRET`). If this is not set, a random key is generated on each startup — all tokens and agent sessions are immediately invalidated on every restart.
+
+**Current state (2026-05-05):** `WOODPECKER_JWT_SECRET` is NOT set in `secrets.env`. Each restart invalidates all sessions. Agents self-heal via the stale-conf fix (#77) and reconnect within ~5 minutes. External API token (`woodpecker-api-token` in GCP SM) is also invalidated.
+
+**Target state (tracked in #92):** woodpecker-deploy.sh rotates the JWT secret on every deploy:
+1. Generates `WOODPECKER_JWT_SECRET` → writes to `secrets.env` + GCP SM
+2. Restarts server with new secret
+3. After health check: self-signs a new API token with the new key
+4. Updates `woodpecker-api-token` in GCP SM
+
+This makes rotation automatic (once per deploy) and eliminates manual intervention after restarts.
+
+**Operator note:** Until #92 lands, any restart will require agents to reconnect (automatic via #77, ~5 min) and may require monitoring tools to wait for the next scrape cycle to clear alerts.
+
+---
+
 ## Reference Incidents
 
 | Date | Symptom | Root cause | Fix |
 |---|---|---|---|
+| 2026-05-05 ~19:08 UTC | All agents disconnected, Grafana red, teams reported WP down | `WOODPECKER_JWT_SECRET` not set — random key generated on each startup invalidates all sessions | Agents self-healed via #77. Permanent fix: automated JWT rotation in woodpecker-deploy.sh (#92) |
+| 2026-05-05 | `database table is locked` under burst webhook load | Write queue (#88) serializes goroutines but xorm pool had 100 SQLite connections — file-level lock still raced | `MaxOpenConns=1` for SQLite (#88) |
 | 2026-05-04 ~20:17 UTC | Server freeze, Slack up/down cascade | `database table is locked` under concurrent writes | Write queue (#55) |
 | 2026-05-04 | pts-build deploy failed (`docker daemon not running`) | Docker masked on d3ci42 post #1403 | Native rsync deploy (#57) |
 | 2026-05-04 | pts-build agent disconnect mid Docker build | Long Docker image build > agent keepalive | Native go build (#57) — shorter, retryable steps |

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -6,19 +6,27 @@
 # Flow:
 #   1. Check GCS for pending-deploy marker; exit 0 if absent
 #   2. Read version, download binary, verify SHA256
-#   3. Stage release: mkdir, rsync, chmod, symlink (atomic)
+#   3. Stage release: mkdir, cp, chmod, atomic symlink swap
 #   4. Restart woodpecker-server via systemctl
-#   5. 90s health check — poll /healthz until version matches or timeout
-#   6. On failure: rollback symlink + restart, Slack alert, remove pending marker
-#   7. On success: prune old releases, remove pending marker, Slack success
+#   5. 90s health check — poll /healthz until X-Woodpecker-Version header matches
+#   6. On success: write version pin file, prune old releases, remove pending marker, Slack
+#   7. On failure: rollback symlink + restart + verify rollback, Slack alert, remove pending marker
 #
-# Alarms: Slack message on failure or health-check timeout.
+# Health check: /healthz returns HTTP 204 with empty body. Version is in the
+# X-Woodpecker-Version response header. Body parsing will always fail — use header.
+#
+# Version pin: /opt/woodpecker/server/deployed-version — written atomically on
+# every successful deploy. Single source of truth for what is actually running.
+# Readable by healthcheck.sh, monitoring, smoke tests.
+#
+# Alarms: Slack on failure or health-check timeout.
 # Idempotent: if pending marker is absent, exits immediately (no-op).
 set -euo pipefail
 
 DEPLOY_BUCKET="gs://ci-runners-de-build-cache/woodpecker-deploy"
 RELEASES_DIR="/opt/woodpecker/server/releases"
 CURRENT_LINK="/opt/woodpecker/server/current"
+VERSION_PIN="/opt/woodpecker/server/deployed-version"
 KEEP_RELEASES=3
 HEALTH_URL="http://localhost:8000/healthz"
 HEALTH_BUDGET=90  # seconds
@@ -33,6 +41,16 @@ slack() {
     [ -z "${SLACK_URL}" ] && return 0
     curl -sf -X POST "${SLACK_URL}" -H "Content-Type: application/json" \
         -d "{\"text\":\"${emoji} *woodpecker-deploy* ${msg}\"}" >/dev/null 2>&1 || true
+}
+
+# healthz_version — query /healthz and return the X-Woodpecker-Version header value.
+# healthz is HTTP 204 with empty body; version lives in the response header only.
+healthz_version() {
+    curl -sf --max-time 5 -D - -o /dev/null "${HEALTH_URL}" 2>/dev/null \
+        | grep -i "^X-Woodpecker-Version:" \
+        | awk '{print $2}' \
+        | tr -d '\r\n' \
+        || echo ""
 }
 
 # ── Exclusive lock — prevent concurrent runs ──
@@ -52,7 +70,7 @@ VERSION=$(echo "${PENDING_CONTENT}" | head -1)
 COMMIT_SHA=$(echo "${PENDING_CONTENT}" | sed -n '2p')
 PIPELINE_NUM=$(echo "${PENDING_CONTENT}" | sed -n '3p')
 
-echo "$(date -u +%FT%TZ) woodpecker-deploy: deploying ${VERSION} (pipeline #${PIPELINE_NUM})"
+echo "$(date -u +%FT%TZ) woodpecker-deploy: deploying ${VERSION} (commit=${COMMIT_SHA:0:8} pipeline=#${PIPELINE_NUM})"
 
 # ── Capture previous release for rollback ──
 PREVIOUS=$(readlink -f "${CURRENT_LINK}" 2>/dev/null | xargs basename 2>/dev/null || echo "")
@@ -84,9 +102,12 @@ fi
 echo "    SHA256 verified: ${ACTUAL_SHA:0:16}..."
 
 # ── Stage release ──
+# Write to .new then mv atomically — direct cp over the running binary fails
+# with "Text file busy" if the same version is already deployed.
 mkdir -p "${RELEASES_DIR}/${VERSION}"
-cp "${STAGE_DIR}/woodpecker-server" "${RELEASES_DIR}/${VERSION}/woodpecker-server"
-chmod 755 "${RELEASES_DIR}/${VERSION}/woodpecker-server"
+cp "${STAGE_DIR}/woodpecker-server" "${RELEASES_DIR}/${VERSION}/woodpecker-server.new"
+chmod 755 "${RELEASES_DIR}/${VERSION}/woodpecker-server.new"
+mv "${RELEASES_DIR}/${VERSION}/woodpecker-server.new" "${RELEASES_DIR}/${VERSION}/woodpecker-server"
 rm -rf "${STAGE_DIR}"
 
 # Atomic symlink swap
@@ -98,18 +119,19 @@ echo "    Restarting woodpecker-server..."
 systemctl restart woodpecker-server
 
 # ── Health check (90s budget) ──
-echo "    Health check (${HEALTH_BUDGET}s budget)..."
+# /healthz returns HTTP 204 with empty body; version is in X-Woodpecker-Version header.
+echo "    Health check (${HEALTH_BUDGET}s budget) — waiting for X-Woodpecker-Version: ${VERSION}..."
 HEALTHY=0
 DEADLINE=$(( $(date +%s) + HEALTH_BUDGET ))
 while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
-    RESPONSE=$(curl -sf --max-time 3 "${HEALTH_URL}" 2>/dev/null || echo "")
-    if [ -n "${RESPONSE}" ]; then
-        STATUS=$(echo "${RESPONSE}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status",""))' 2>/dev/null || echo "")
-        VERSION_SERVED=$(echo "${RESPONSE}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("version",""))' 2>/dev/null || echo "")
-        echo "    healthz: status=${STATUS} version=${VERSION_SERVED}"
-        if [ "${STATUS}" = "ok" ] && [ "${VERSION_SERVED}" = "${VERSION}" ]; then
+    VERSION_SERVED=$(healthz_version)
+    if [ -n "${VERSION_SERVED}" ]; then
+        echo "    healthz: X-Woodpecker-Version=${VERSION_SERVED}"
+        if [ "${VERSION_SERVED}" = "${VERSION}" ]; then
             HEALTHY=1
             break
+        else
+            echo "    version mismatch — served=${VERSION_SERVED} expected=${VERSION}"
         fi
     fi
     sleep 5
@@ -117,27 +139,36 @@ done
 
 if [ "${HEALTHY}" -ne 1 ]; then
     echo "ERROR: health check timed out after ${HEALTH_BUDGET}s — rolling back to ${PREVIOUS:-<none>}"
-    # Rollback
+    ROLLBACK_STATUS="no rollback target"
     if [ -n "${PREVIOUS}" ] && [ -d "${RELEASES_DIR}/${PREVIOUS}" ]; then
         ln -sfn "${RELEASES_DIR}/${PREVIOUS}" "${CURRENT_LINK}"
         systemctl restart woodpecker-server
+        # Verify rollback — same header check
         sleep 5
-        ROLLBACK_OK=$(curl -sf --max-time 5 "${HEALTH_URL}" 2>/dev/null | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("status",""))' 2>/dev/null || echo "")
-        if [ "${ROLLBACK_OK}" = "ok" ]; then
-            echo "    Rolled back to ${PREVIOUS} — server healthy"
-            slack ":rotating_light:" "deploy ${VERSION} FAILED (health-check timeout). Rolled back to \`${PREVIOUS}\`. Server healthy. Pipeline #${PIPELINE_NUM}. Manual investigation required."
+        ROLLBACK_VERSION=$(healthz_version)
+        if [ "${ROLLBACK_VERSION}" = "${PREVIOUS}" ]; then
+            ROLLBACK_STATUS="rolled back to ${PREVIOUS} ✅"
+            echo "    ${ROLLBACK_STATUS}"
+            slack ":rotating_light:" "deploy ${VERSION} FAILED (health-check timeout). ${ROLLBACK_STATUS}. Pipeline #${PIPELINE_NUM}. Manual investigation required."
         else
-            slack ":sos:" "deploy ${VERSION} FAILED + rollback FAILED. woodpecker-server may be DOWN. Pipeline #${PIPELINE_NUM}. Immediate attention required."
+            ROLLBACK_STATUS="rollback FAILED (healthz returned '${ROLLBACK_VERSION}')"
+            echo "ERROR: ${ROLLBACK_STATUS}"
+            slack ":sos:" "deploy ${VERSION} FAILED + ${ROLLBACK_STATUS}. woodpecker-server may be DOWN. Pipeline #${PIPELINE_NUM}. Immediate attention required."
         fi
     else
-        slack ":sos:" "deploy ${VERSION} FAILED (health-check timeout) + no rollback target. woodpecker-server may be DOWN. Pipeline #${PIPELINE_NUM}. Immediate attention required."
+        slack ":sos:" "deploy ${VERSION} FAILED (health-check timeout) + ${ROLLBACK_STATUS}. woodpecker-server may be DOWN. Pipeline #${PIPELINE_NUM}. Immediate attention required."
     fi
     gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
     exit 1
 fi
 
-# ── Success ──
-echo "✅ ${VERSION} deployed and healthy"
+# ── Success — write version pin, prune, clean up ──
+echo "✅ ${VERSION} deployed and healthy (X-Woodpecker-Version verified)"
+
+# Write version pin file — well-known location for healthcheck.sh, monitoring, smoke tests
+printf '%s\n' "${VERSION}" > "${VERSION_PIN}.new"
+mv "${VERSION_PIN}.new" "${VERSION_PIN}"
+echo "    Version pin: ${VERSION_PIN} = ${VERSION}"
 
 # Prune old releases (keep KEEP_RELEASES most recent)
 find "${RELEASES_DIR}" -maxdepth 1 -mindepth 1 -type d | sort -r | \
@@ -149,6 +180,6 @@ done
 # Remove pending marker
 gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
 
-slack ":white_check_mark:" "woodpecker-server \`${VERSION}\` deployed to d3ci42. Pipeline #${PIPELINE_NUM}. Commit: \`${COMMIT_SHA:0:8}\`."
+slack ":white_check_mark:" "woodpecker-server \`${VERSION}\` deployed to d3ci42. Commit: \`${COMMIT_SHA:0:8}\`. Pipeline #${PIPELINE_NUM}."
 
 echo "$(date -u +%FT%TZ) woodpecker-deploy: ${VERSION} complete"


### PR DESCRIPTION
pts-build is the only legitimate use of backend:local. Removed incorrectly during the sweep. Closes #96.