### PR TITLE
fix: pts-wake.sh WebSocket transport for pentest-dev-vm (#99)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh uses WebSocket transport for pentest-dev-vm agent — port 9000 (gRPC direct) is localhost-only on d3ci42; external VMs must connect via WebSocket through Caddy TLS (#99)
 - fix: restore `backend: local` to pts-build.yaml — removed incorrectly during backend:local sweep; pts-build is the only legitimate use and must run on d3ci42-local (#96)
 - fix: woodpecker-deploy.sh health check was parsing JSON body that does not exist — healthz returns HTTP 204 with empty body, version is in X-Woodpecker-Version response header; cp over running binary fixed with .new + mv pattern; deployed-version pin file written atomically on success (#90)
 

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -11,7 +11,7 @@ PENTEST_ZONE="us-central1-a"
 PENTEST_VM="pentest-dev-vm"
 TTL_MINUTES=60  # generous budget: wake + compile + deploy
 
-WP_SERVER="d3ci42.peregrinetechsys.net:443"  # Caddy proxies gRPC → port 9000
+WP_SERVER="d3ci42.peregrinetechsys.net"  # WebSocket via Caddy TLS (port 443)
 VERSION="v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}"
 
 # ── Concurrent-run guard ──
@@ -107,6 +107,8 @@ $PTS_SSH "root@${PENTEST_IP}" "
     nohup env \
         WOODPECKER_SERVER='${WP_SERVER}' \
         WOODPECKER_AGENT_SECRET='${AGENT_SECRET}' \
+        WOODPECKER_AGENT_TRANSPORT=ws \
+        WOODPECKER_GRPC_SECURE=true \
         WOODPECKER_BACKEND=local \
         WOODPECKER_AGENT_LABELS='agent=pts-build' \
         WOODPECKER_HOSTNAME='pentest-dev-vm' \


### PR DESCRIPTION
Port 9000 is localhost-only on d3ci42. Agent on pentest-dev-vm needs WebSocket via Caddy. Verified working. Closes #99.