### PR TITLE
fix: delete stale agent.conf on RegisterAgent auth failure (#101)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: agent stale-conf self-heal now covers RegisterAgent() auth failure — deletes agent.conf before exiting so systemd restart re-registers fresh instead of crash-looping on the same stale AgentID (#101)
 - fix: pts-wake.sh uses WebSocket transport for pentest-dev-vm agent — port 9000 (gRPC direct) is localhost-only on d3ci42; external VMs must connect via WebSocket through Caddy TLS (#99)
 - fix: restore `backend: local` to pts-build.yaml — removed incorrectly during backend:local sweep; pts-build is the only legitimate use and must run on d3ci42-local (#96)
 - fix: woodpecker-deploy.sh health check was parsing JSON body that does not exist — healthz returns HTTP 204 with empty body, version is in X-Woodpecker-Version response header; cp over running binary fixed with .new + mv pattern; deployed-version pin file written atomically on success (#90)

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -240,6 +240,21 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 		CustomLabels: customLabels,
 	})
 	if err != nil {
+		// Stale conf: AgentID in agent.conf no longer exists in the server DB
+		// (server restart clears agents). Delete the conf so the next systemd
+		// restart re-registers fresh instead of crash-looping on the same ID. (#101)
+		if s, ok := status.FromError(err); ok {
+			msg := s.Message()
+			if strings.Contains(msg, "AgentID not found") ||
+				strings.Contains(msg, "sql: no rows") ||
+				strings.Contains(msg, "token is expired") {
+				if agentConfigPath != "" {
+					if removeErr := os.Remove(agentConfigPath); removeErr == nil {
+						log.Warn().Str("path", agentConfigPath).Msg("removed stale agent.conf — next start will re-register (#101)")
+					}
+				}
+			}
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes crash loop: agent reads stale AgentID from conf, RegisterAgent fails, systemd restarts, repeat. Now deletes conf before returning so next restart re-registers fresh. Closes #101.