### PR TITLE
fix: remove sql:no-rows from runner-loop stale-conf check (#103)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: remove sql:no-rows from runner-loop stale-conf check — next() legitimately returns this when no tasks are pending; false positive was calling log.Fatal() mid-task, killing in-flight wake steps (#103)
 - fix: agent stale-conf self-heal now covers RegisterAgent() auth failure — deletes agent.conf before exiting so systemd restart re-registers fresh instead of crash-looping on the same stale AgentID (#101)
 - fix: pts-wake.sh uses WebSocket transport for pentest-dev-vm agent — port 9000 (gRPC direct) is localhost-only on d3ci42; external VMs must connect via WebSocket through Caddy TLS (#99)
 - fix: restore `backend: local` to pts-build.yaml — removed incorrectly during backend:local sweep; pts-build is the only legitimate use and must run on d3ci42-local (#96)

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -346,8 +346,10 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 						if s, ok := status.FromError(err); ok {
 							msg := s.Message()
 							if strings.Contains(msg, "token is expired") ||
-								strings.Contains(msg, "AgentID not found") ||
-								strings.Contains(msg, "sql: no rows") {
+								strings.Contains(msg, "AgentID not found") {
+								// Note: "sql: no rows" is intentionally excluded — next() returns
+								// this normally when no tasks are pending. It is a stale-conf
+								// signal only at RegisterAgent() time (handled in #101/#102). (#103)
 								log.Fatal().Err(err).Msg("agent auth failed with stale credentials — exiting for systemd restart (#77)")
 							}
 						}


### PR DESCRIPTION
next() returns sql:no-rows normally when no tasks are pending. False positive was killing the agent mid-wake-step. Closes #103.