### PR TITLE
fix: dedicated SQLite writer connection, reader pool MaxOpenConns=10 (#107)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: dedicated SQLite writer connection — MaxOpenConns=1 on a separate xorm engine used exclusively by the write queue drain goroutine; reader pool stays at MaxOpenConns=10. Previous MaxOpenConns=1 on the shared engine caused reads to see phantom sql:no-rows because the single connection was mid-write, killing in-flight agent health reports and pipeline steps (#107)
 - fix: pts-wake.sh agent start uses setsid+bash instead of nohup — nohup unreliable when SSH session closes before agent initialises; adds post-start PID verification and extends poll to 150s (#105)
 - fix: remove sql:no-rows from runner-loop stale-conf check — next() legitimately returns this when no tasks are pending; false positive was calling log.Fatal() mid-task, killing in-flight wake steps (#103)
 - fix: agent stale-conf self-heal now covers RegisterAgent() auth failure — deletes agent.conf before exiting so systemd restart re-registers fresh instead of crash-looping on the same stale AgentID (#101)

--- a/server/store/datastore/agent.go
+++ b/server/store/datastore/agent.go
@@ -43,20 +43,20 @@ func (s storage) AgentFindByToken(token string) (*model.Agent, error) {
 func (s storage) AgentCreate(agent *model.Agent) error {
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(agent))
+		return wrapInsert(s.writeEngine().Insert(agent))
 	})
 }
 
 func (s storage) AgentUpdate(agent *model.Agent) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(agent.ID).AllCols().Update(agent)
+		_, err := s.writeEngine().ID(agent.ID).AllCols().Update(agent)
 		return err
 	})
 }
 
 func (s storage) AgentDelete(agent *model.Agent) error {
 	return s.wq.serialize(func() error {
-		return wrapDelete(s.engine.ID(agent.ID).Delete(new(model.Agent)))
+		return wrapDelete(s.writeEngine().ID(agent.ID).Delete(new(model.Agent)))
 	})
 }
 

--- a/server/store/datastore/config.go
+++ b/server/store/datastore/config.go
@@ -50,7 +50,7 @@ func (s storage) ConfigPersist(conf *model.Config) (*model.Config, error) {
 
 	var result *model.Config
 	err := s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err
@@ -94,6 +94,6 @@ func (s storage) configCreate(sess *xorm.Session, config *model.Config) error {
 func (s storage) PipelineConfigCreate(config *model.PipelineConfig) error {
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(config))
+		return wrapInsert(s.writeEngine().Insert(config))
 	})
 }

--- a/server/store/datastore/cron.go
+++ b/server/store/datastore/cron.go
@@ -29,7 +29,7 @@ func (s storage) CronCreate(cron *model.Cron) error {
 		return err
 	}
 	return s.wq.serialize(func() error {
-		err := wrapInsert(s.engine.Insert(cron))
+		err := wrapInsert(s.writeEngine().Insert(cron))
 		if errors.Is(err, types.ErrInsertDuplicateDetected) {
 			return fmt.Errorf("create cron failed, duplicate detected: %w", err)
 		}
@@ -49,14 +49,14 @@ func (s storage) CronList(repo *model.Repo, p *model.ListOptions) ([]*model.Cron
 
 func (s storage) CronUpdate(_ *model.Repo, cron *model.Cron) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(cron.ID).AllCols().Update(cron)
+		_, err := s.writeEngine().ID(cron.ID).AllCols().Update(cron)
 		return err
 	})
 }
 
 func (s storage) CronDelete(repo *model.Repo, id int64) error {
 	return s.wq.serialize(func() error {
-		return wrapDelete(s.engine.ID(id).Where("repo_id = ?", repo.ID).Delete(new(model.Cron)))
+		return wrapDelete(s.writeEngine().ID(id).Where("repo_id = ?", repo.ID).Delete(new(model.Cron)))
 	})
 }
 
@@ -70,7 +70,7 @@ func (s storage) CronListNextExecute(nextExec, limit int64) ([]*model.Cron, erro
 func (s storage) CronGetLock(cron *model.Cron, newNextExec int64) (bool, error) {
 	var gotLock bool
 	err := s.wq.serialize(func() error {
-		cols, err := s.engine.ID(cron.ID).Where(builder.Eq{"next_exec": cron.NextExec}).
+		cols, err := s.writeEngine().ID(cron.ID).Where(builder.Eq{"next_exec": cron.NextExec}).
 			Cols("next_exec").Update(&model.Cron{NextExec: newNextExec})
 		gotLock = cols != 0
 		if err == nil && gotLock {

--- a/server/store/datastore/engine.go
+++ b/server/store/datastore/engine.go
@@ -26,13 +26,27 @@ import (
 )
 
 type storage struct {
-	engine *xorm.Engine
+	engine *xorm.Engine // reader pool (MaxOpenConns=10 for SQLite, opts value for others)
+	// writer is a dedicated single-connection engine used exclusively by the
+	// write queue drain goroutine for SQLite. Separating read and write
+	// connections lets WAL serve concurrent reads while guaranteeing a single
+	// writer at the SQLite level (#107). nil for non-SQLite drivers.
+	writer *xorm.Engine
 	// wq serializes writes for SQLite to prevent SQLITE_BUSY under concurrent
 	// load (#55). nil for non-SQLite drivers (serialize() calls fn directly).
 	wq *writeQueue
 }
 
 const perPage = 50
+
+// writeEngine returns the dedicated writer connection for SQLite, or the
+// shared engine for other drivers. Use this inside s.wq.serialize closures.
+func (s storage) writeEngine() *xorm.Engine {
+	if s.writer != nil {
+		return s.writer
+	}
+	return s.engine
+}
 
 func NewEngine(opts *store.Opts) (store.Store, error) {
 	dsn := opts.Config
@@ -58,13 +72,26 @@ func NewEngine(opts *store.Opts) (store.Store, error) {
 
 	s := &storage{engine: engine}
 	if opts.Driver == "sqlite3" {
+		// Reader pool: allow concurrent reads via WAL. Capped at 10 — d3ci42
+		// is a small machine and hitting 10 simultaneous readers is unlikely.
+		engine.SetMaxOpenConns(10)
+		engine.SetMaxIdleConns(5)
+
+		// Dedicated writer: a separate single-connection engine used only by the
+		// write queue drain goroutine. WAL allows readers and this one writer to
+		// coexist without blocking. MaxOpenConns=1 here guarantees no goroutine
+		// other than the drain goroutine ever opens a write connection (#107).
+		writer, err := xorm.NewEngine(opts.Driver, dsn)
+		if err != nil {
+			return nil, err
+		}
+		writer.SetLogger(logger)
+		writer.ShowSQL(opts.XORM.ShowSQL)
+		writer.SetMaxOpenConns(1)
+		writer.SetMaxIdleConns(1)
+		s.writer = writer
+
 		s.wq = newWriteQueue(writeQueueDepth)
-		// Single connection required: the write queue serializes Go-level writes
-		// through one goroutine, but xorm's pool can open multiple SQLite file
-		// handles. SQLite's write lock is per-connection — multiple handles race
-		// on it even with the queue, producing SQLITE_BUSY under burst load (#88).
-		engine.SetMaxOpenConns(1)
-		engine.SetMaxIdleConns(1)
 	}
 	return s, nil
 }

--- a/server/store/datastore/forge.go
+++ b/server/store/datastore/forge.go
@@ -31,20 +31,20 @@ func (s storage) ForgeList(p *model.ListOptions) ([]*model.Forge, error) {
 func (s storage) ForgeCreate(forge *model.Forge) error {
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(forge))
+		return wrapInsert(s.writeEngine().Insert(forge))
 	})
 }
 
 func (s storage) ForgeUpdate(forge *model.Forge) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(forge.ID).AllCols().Update(forge)
+		_, err := s.writeEngine().ID(forge.ID).AllCols().Update(forge)
 		return err
 	})
 }
 
 func (s storage) ForgeDelete(forge *model.Forge) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err

--- a/server/store/datastore/log.go
+++ b/server/store/datastore/log.go
@@ -41,7 +41,7 @@ func (s storage) LogAppend(_ *model.Step, logEntries []*model.LogEntry) error {
 			end := min(pgBatchSize, len(logEntries[i:]))
 			chunk := logEntries[i : i+end]
 
-			if err := wrapInsert(s.engine.Insert(chunk)); err != nil {
+			if err := wrapInsert(s.writeEngine().Insert(chunk)); err != nil {
 				log.Error().Err(err).Msg("could not store log entries to db")
 				errs = errors.Join(errs, err)
 			}
@@ -53,7 +53,7 @@ func (s storage) LogAppend(_ *model.Step, logEntries []*model.LogEntry) error {
 
 func (s storage) LogDelete(step *model.Step) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		return logDelete(sess, step.ID)
 	})

--- a/server/store/datastore/org.go
+++ b/server/store/datastore/org.go
@@ -25,7 +25,7 @@ import (
 
 func (s storage) OrgCreate(org *model.Org) error {
 	return s.wq.serialize(func() error {
-		return s.orgCreate(org, s.engine.NewSession())
+		return s.orgCreate(org, s.writeEngine().NewSession())
 	})
 }
 
@@ -43,7 +43,7 @@ func (s storage) OrgGet(id int64) (*model.Org, error) {
 
 func (s storage) OrgUpdate(org *model.Org) error {
 	return s.wq.serialize(func() error {
-		return s.orgUpdate(s.engine.NewSession(), org)
+		return s.orgUpdate(s.writeEngine().NewSession(), org)
 	})
 }
 
@@ -55,7 +55,7 @@ func (s storage) orgUpdate(sess *xorm.Session, org *model.Org) error {
 
 func (s storage) OrgDelete(id int64) error {
 	return s.wq.serialize(func() error {
-		return s.orgDelete(s.engine.NewSession(), id)
+		return s.orgDelete(s.writeEngine().NewSession(), id)
 	})
 }
 

--- a/server/store/datastore/permission.go
+++ b/server/store/datastore/permission.go
@@ -33,7 +33,7 @@ func (s storage) PermFind(user *model.User, repo *model.Repo) (*model.Perm, erro
 
 func (s storage) PermUpsert(perm *model.Perm) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err
@@ -91,11 +91,11 @@ func userIDAndRepoIDCond(perm *model.Perm) builder.Cond {
 func (s storage) PermPrune(userID int64, keepRepoIDs []int64) error {
 	return s.wq.serialize(func() error {
 		if len(keepRepoIDs) == 0 {
-			_, err := s.engine.Where(builder.Eq{"user_id": userID}).Delete(new(model.Perm))
+			_, err := s.writeEngine().Where(builder.Eq{"user_id": userID}).Delete(new(model.Perm))
 			return err
 		}
 
-		_, err := s.engine.Where(builder.Eq{"user_id": userID}).
+		_, err := s.writeEngine().Where(builder.Eq{"user_id": userID}).
 			And(builder.NotIn("repo_id", keepRepoIDs)).
 			Delete(new(model.Perm))
 		return err

--- a/server/store/datastore/pipeline.go
+++ b/server/store/datastore/pipeline.go
@@ -161,7 +161,7 @@ func (s storage) CreatePipeline(pipeline *model.Pipeline, stepList ...*model.Ste
 
 		// Execute with backoff retry
 		_, err := backoff.Retry(context.Background(), func() (struct{}, error) {
-			sess := s.engine.NewSession()
+			sess := s.writeEngine().NewSession()
 			defer sess.Close()
 			if err := sess.Begin(); err != nil {
 				return struct{}{}, err
@@ -230,14 +230,14 @@ func isUniqueConstraintError(err error) bool {
 
 func (s storage) UpdatePipeline(pipeline *model.Pipeline) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(pipeline.ID).AllCols().Update(pipeline)
+		_, err := s.writeEngine().ID(pipeline.ID).AllCols().Update(pipeline)
 		return err
 	})
 }
 
 func (s storage) DeletePipeline(pipeline *model.Pipeline) error {
 	return s.wq.serialize(func() error {
-		return s.deletePipeline(s.engine.NewSession(), pipeline.ID)
+		return s.deletePipeline(s.writeEngine().NewSession(), pipeline.ID)
 	})
 }
 

--- a/server/store/datastore/redirection.go
+++ b/server/store/datastore/redirection.go
@@ -28,7 +28,7 @@ func (s storage) getRedirection(e *xorm.Session, fullName string) (*model.Redire
 
 func (s storage) CreateRedirection(redirect *model.Redirection) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		return s.createRedirection(sess, redirect)
 	})

--- a/server/store/datastore/registry.go
+++ b/server/store/datastore/registry.go
@@ -47,20 +47,20 @@ func (s storage) RegistryListAll() ([]*model.Registry, error) {
 func (s storage) RegistryCreate(registry *model.Registry) error {
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(registry))
+		return wrapInsert(s.writeEngine().Insert(registry))
 	})
 }
 
 func (s storage) RegistryUpdate(registry *model.Registry) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(registry.ID).AllCols().Update(registry)
+		_, err := s.writeEngine().ID(registry.ID).AllCols().Update(registry)
 		return err
 	})
 }
 
 func (s storage) RegistryDelete(registry *model.Registry) error {
 	return s.wq.serialize(func() error {
-		return wrapDelete(s.engine.ID(registry.ID).Delete(new(model.Registry)))
+		return wrapDelete(s.writeEngine().ID(registry.ID).Delete(new(model.Registry)))
 	})
 }
 

--- a/server/store/datastore/repo.go
+++ b/server/store/datastore/repo.go
@@ -91,20 +91,20 @@ func (s storage) CreateRepo(repo *model.Repo) error {
 	}
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(repo))
+		return wrapInsert(s.writeEngine().Insert(repo))
 	})
 }
 
 func (s storage) UpdateRepo(repo *model.Repo) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(repo.ID).AllCols().Update(repo)
+		_, err := s.writeEngine().ID(repo.ID).AllCols().Update(repo)
 		return err
 	})
 }
 
 func (s storage) DeleteRepo(repo *model.Repo) error {
 	return s.wq.serialize(func() error {
-		return s.deleteRepo(s.engine.NewSession(), repo)
+		return s.deleteRepo(s.writeEngine().NewSession(), repo)
 	})
 }
 

--- a/server/store/datastore/secret.go
+++ b/server/store/datastore/secret.go
@@ -47,20 +47,20 @@ func (s storage) SecretListAll() ([]*model.Secret, error) {
 func (s storage) SecretCreate(secret *model.Secret) error {
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(secret))
+		return wrapInsert(s.writeEngine().Insert(secret))
 	})
 }
 
 func (s storage) SecretUpdate(secret *model.Secret) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(secret.ID).AllCols().Update(secret)
+		_, err := s.writeEngine().ID(secret.ID).AllCols().Update(secret)
 		return err
 	})
 }
 
 func (s storage) SecretDelete(secret *model.Secret) error {
 	return s.wq.serialize(func() error {
-		return wrapDelete(s.engine.ID(secret.ID).Delete(new(model.Secret)))
+		return wrapDelete(s.writeEngine().ID(secret.ID).Delete(new(model.Secret)))
 	})
 }
 

--- a/server/store/datastore/server_config.go
+++ b/server/store/datastore/server_config.go
@@ -32,7 +32,7 @@ func (s storage) ServerConfigSet(key, value string) error {
 			Key: key,
 		}
 
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err
@@ -64,6 +64,6 @@ func (s storage) ServerConfigDelete(key string) error {
 			Key: key,
 		}
 
-		return wrapDelete(s.engine.Delete(config))
+		return wrapDelete(s.writeEngine().Delete(config))
 	})
 }

--- a/server/store/datastore/step.go
+++ b/server/store/datastore/step.go
@@ -80,7 +80,7 @@ func (s storage) stepCreate(sess *xorm.Session, steps []*model.Step) error {
 
 func (s storage) StepUpdate(step *model.Step) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(step.ID).AllCols().Update(step)
+		_, err := s.writeEngine().ID(step.ID).AllCols().Update(step)
 		return err
 	})
 }

--- a/server/store/datastore/task.go
+++ b/server/store/datastore/task.go
@@ -26,12 +26,12 @@ func (s storage) TaskList() ([]*model.Task, error) {
 func (s storage) TaskInsert(task *model.Task) error {
 	return s.wq.serialize(func() error {
 		// only Insert set auto created ID back to object
-		return wrapInsert(s.engine.Insert(task))
+		return wrapInsert(s.writeEngine().Insert(task))
 	})
 }
 
 func (s storage) TaskDelete(id string) error {
 	return s.wq.serialize(func() error {
-		return wrapDelete(s.engine.Where("id = ?", id).Delete(new(model.Task)))
+		return wrapDelete(s.writeEngine().Where("id = ?", id).Delete(new(model.Task)))
 	})
 }

--- a/server/store/datastore/user.go
+++ b/server/store/datastore/user.go
@@ -50,7 +50,7 @@ func (s storage) GetUserCount() (int64, error) {
 
 func (s storage) CreateUser(user *model.User) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		org := &model.Org{
 			Name:    user.Login,
 			ForgeID: user.ForgeID,
@@ -84,14 +84,14 @@ func (s storage) CreateUser(user *model.User) error {
 
 func (s storage) UpdateUser(user *model.User) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(user.ID).AllCols().Update(user)
+		_, err := s.writeEngine().ID(user.ID).AllCols().Update(user)
 		return err
 	})
 }
 
 func (s storage) DeleteUser(user *model.User) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err

--- a/server/store/datastore/workflow.go
+++ b/server/store/datastore/workflow.go
@@ -39,7 +39,7 @@ func (s storage) WorkflowGetTree(pipeline *model.Pipeline) ([]*model.Workflow, e
 
 func (s storage) WorkflowsCreate(workflows []*model.Workflow) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err
@@ -69,7 +69,7 @@ func (s storage) workflowsCreate(sess *xorm.Session, workflows []*model.Workflow
 // WorkflowsReplace performs an atomic replacement of workflows and associated steps by deleting all existing workflows and steps and inserting the new ones.
 func (s storage) WorkflowsReplace(pipeline *model.Pipeline, workflows []*model.Workflow) error {
 	return s.wq.serialize(func() error {
-		sess := s.engine.NewSession()
+		sess := s.writeEngine().NewSession()
 		defer sess.Close()
 		if err := sess.Begin(); err != nil {
 			return err
@@ -133,7 +133,7 @@ func (s storage) WorkflowLoad(id int64) (*model.Workflow, error) {
 
 func (s storage) WorkflowUpdate(workflow *model.Workflow) error {
 	return s.wq.serialize(func() error {
-		_, err := s.engine.ID(workflow.ID).AllCols().Update(workflow)
+		_, err := s.writeEngine().ID(workflow.ID).AllCols().Update(workflow)
 		return err
 	})
 }


### PR DESCRIPTION
Two xorm engines for SQLite: reader pool (MaxOpenConns=10) for all reads, dedicated writer (MaxOpenConns=1) exclusively for the write queue drain goroutine. Eliminates phantom sql:no-rows that were killing in-flight pipeline steps. Closes #107.