### PR TITLE
fix: pts-cleanup.sh mutex guard — skip stop-vm if VM owned by newer pipeline (#109)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: pts-cleanup.sh skips stop-vm when VM is owned by a newer pipeline — prevents concurrent cleanup from killing a newer wake step mid-boot (#109)
 - fix: dedicated SQLite writer connection — MaxOpenConns=1 on a separate xorm engine used exclusively by the write queue drain goroutine; reader pool stays at MaxOpenConns=10. Previous MaxOpenConns=1 on the shared engine caused reads to see phantom sql:no-rows because the single connection was mid-write, killing in-flight agent health reports and pipeline steps (#107)
 - fix: pts-wake.sh agent start uses setsid+bash instead of nohup — nohup unreliable when SSH session closes before agent initialises; adds post-start PID verification and extends poll to 150s (#105)
 - fix: remove sql:no-rows from runner-loop stale-conf check — next() legitimately returns this when no tasks are pending; false positive was calling log.Fatal() mid-task, killing in-flight wake steps (#103)

--- a/scripts/woodpecker/pts-cleanup.sh
+++ b/scripts/woodpecker/pts-cleanup.sh
@@ -9,13 +9,26 @@ PENTEST_PROJECT="peregrine-pentest-dev"
 PENTEST_ZONE="us-central1-a"
 PENTEST_VM="pentest-dev-vm"
 
-echo "==> Stopping ${PENTEST_VM}..."
-gcloud compute instances stop "${PENTEST_VM}" \
-    --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" --quiet 2>/dev/null && \
-    echo "    stopped" || echo "    ⚠️  stop failed or VM already stopped (non-fatal)"
-
-echo "==> Removing TTL labels..."
-gcloud compute instances remove-labels "${PENTEST_VM}" \
+# Mutex guard: the wake step labels the VM with pts-build-pipeline=N.
+# If a newer pipeline has already claimed the VM, skip the stop — we'd
+# be killing a concurrent wake step mid-boot (#109).
+MY_PIPELINE="${CI_PIPELINE_NUMBER:-0}"
+OWNER_PIPELINE=$(gcloud compute instances describe "${PENTEST_VM}" \
     --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
-    --labels=ttl-expire-epoch,pts-build-pipeline 2>/dev/null && \
-    echo "    labels removed" || echo "    ⚠️  label removal failed (non-fatal)"
+    --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "")
+echo "==> Mutex check: my pipeline=#${MY_PIPELINE} owner=#${OWNER_PIPELINE:-unknown}"
+
+if [ -n "${OWNER_PIPELINE}" ] && [ "${OWNER_PIPELINE}" -gt "${MY_PIPELINE}" ] 2>/dev/null; then
+    echo "    VM owned by newer pipeline #${OWNER_PIPELINE} — skipping stop (superseded)"
+else
+    echo "==> Stopping ${PENTEST_VM}..."
+    gcloud compute instances stop "${PENTEST_VM}" \
+        --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" --quiet 2>/dev/null && \
+        echo "    stopped" || echo "    ⚠️  stop failed or VM already stopped (non-fatal)"
+
+    echo "==> Removing TTL labels..."
+    gcloud compute instances remove-labels "${PENTEST_VM}" \
+        --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+        --labels=ttl-expire-epoch,pts-build-pipeline 2>/dev/null && \
+        echo "    labels removed" || echo "    ⚠️  label removal failed (non-fatal)"
+fi


### PR DESCRIPTION
Prevents concurrent cleanup from killing a newer pipeline's wake step mid-boot. Reads `pts-build-pipeline` label; skips stop if owner > own pipeline number. Closes #109.