### PR TITLE
fix: reader pool must not use _txlock=immediate — removes RESERVED lock contention on webhook bursts (#114)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: SQLite reader pool no longer uses _txlock=immediate — applying BEGIN IMMEDIATE to reader connections caused all 10 pool connections to compete for the same RESERVED lock under concurrent webhook load, producing "database table is locked: pipelines" on POST /api/hook even after the dedicated-writer fix (#107). Reader DSN now uses deferred locking (SQLite default); _txlock=immediate is kept only on the single writer connection where it prevents upgrade-deadlocks (#114)
+
 - fix: pts-build.sh runs go build under `nice -n 10` — lowers CPU priority of the compile so the agent's WebSocket heartbeat goroutine is scheduled even under full-core saturation; prevents keepalive misses that drop the session and kill the compile (#115)
 - fix: pts-wake.sh sets WOODPECKER_GRPC_KEEPALIVE_TIME=10s and WOODPECKER_GRPC_KEEPALIVE_TIMEOUT=20s — shorter ping interval with a longer timeout gives the server more tolerance for heartbeats missed during CPU-intensive compile on pentest-dev-vm (#115)
 - fix: woodpecker-agent.service and scaler.service changed from Requires= to Wants= for woodpecker-server.service — Requires= cascaded server restarts to kill both the agent and scaler simultaneously; Wants= keeps them alive through a server restart and lets them reconnect when the server returns (#112 — SSH-applied to d3ci42, codified in nfpm template)

--- a/server/store/datastore/engine.go
+++ b/server/store/datastore/engine.go
@@ -50,10 +50,18 @@ func (s storage) writeEngine() *xorm.Engine {
 
 func NewEngine(opts *store.Opts) (store.Store, error) {
 	dsn := opts.Config
+	// Reader DSN: WAL + busy_timeout, but NO _txlock=immediate.
+	// Readers use deferred locking so they do not compete for the RESERVED lock
+	// that the writer holds. Applying _txlock=immediate to readers caused all
+	// reader connections to fight for the same lock under concurrent webhook
+	// load, producing "database table is locked" on /api/hook (#114).
+	readerDSN := dsn
+	writerDSN := dsn
 	if opts.Driver == "sqlite3" {
-		dsn = applySqliteDefaults(dsn)
+		readerDSN = applySQLiteReaderDefaults(dsn)
+		writerDSN = applySQLiteWriterDefaults(dsn)
 	}
-	engine, err := xorm.NewEngine(opts.Driver, dsn)
+	engine, err := xorm.NewEngine(opts.Driver, readerDSN)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +89,8 @@ func NewEngine(opts *store.Opts) (store.Store, error) {
 		// write queue drain goroutine. WAL allows readers and this one writer to
 		// coexist without blocking. MaxOpenConns=1 here guarantees no goroutine
 		// other than the drain goroutine ever opens a write connection (#107).
-		writer, err := xorm.NewEngine(opts.Driver, dsn)
+		// Uses _txlock=immediate to prevent upgrade-deadlocks on the write path.
+		writer, err := xorm.NewEngine(opts.Driver, writerDSN)
 		if err != nil {
 			return nil, err
 		}

--- a/server/store/datastore/sqlite_dsn.go
+++ b/server/store/datastore/sqlite_dsn.go
@@ -13,31 +13,57 @@ import (
 	"strings"
 )
 
-// sqliteSafeDefaults is the minimum set of pragmas that lets Woodpecker
-// survive concurrent webhook bursts without SQLITE_BUSY "database is locked"
-// errors on /api/hook. See woodpecker-server#10 for the incident analysis.
-var sqliteSafeDefaults = map[string]string{
+// sqliteReaderDefaults are pragmas applied to the reader connection pool.
+// _txlock is intentionally absent — reader transactions use SQLite's default
+// deferred locking so they do NOT acquire a RESERVED lock at BEGIN. Applying
+// _txlock=immediate to readers causes all reader connections to compete for the
+// same RESERVED lock, blocking the writer and each other under concurrent load
+// (#114).
+var sqliteReaderDefaults = map[string]string{
+	"_busy_timeout": "30000",
+	"_journal_mode": "WAL",
+	"_synchronous":  "NORMAL",
+}
+
+// sqliteWriterDefaults are pragmas applied to the single dedicated writer
+// connection. _txlock=immediate acquires a RESERVED lock at BEGIN, preventing
+// the upgrade-deadlock that can occur when a deferred transaction reads then
+// tries to write while another writer is active.
+var sqliteWriterDefaults = map[string]string{
 	"_busy_timeout": "30000",
 	"_journal_mode": "WAL",
 	"_synchronous":  "NORMAL",
 	"_txlock":       "immediate",
 }
 
-// applySqliteDefaults merges sqliteSafeDefaults into the DSN, preserving any
-// value the operator has already set. Invoked from NewEngine when the driver
-// is sqlite3.
-func applySqliteDefaults(dsn string) string {
+// applySQLiteReaderDefaults merges sqliteReaderDefaults into the DSN.
+func applySQLiteReaderDefaults(dsn string) string {
+	return applySQLiteDefaults(dsn, sqliteReaderDefaults)
+}
+
+// applySQLiteWriterDefaults merges sqliteWriterDefaults into the DSN.
+func applySQLiteWriterDefaults(dsn string) string {
+	return applySQLiteDefaults(dsn, sqliteWriterDefaults)
+}
+
+func applySQLiteDefaults(dsn string, defaults map[string]string) string {
 	base, rawQuery := splitSqliteDSN(dsn)
 	values, err := url.ParseQuery(rawQuery)
 	if err != nil {
 		values = url.Values{}
 	}
-	for k, v := range sqliteSafeDefaults {
+	for k, v := range defaults {
 		if values.Get(k) == "" {
 			values.Set(k, v)
 		}
 	}
 	return base + "?" + values.Encode()
+}
+
+// applySqliteDefaults is kept for backward compatibility with existing tests.
+// New code should call applySQLiteReaderDefaults or applySQLiteWriterDefaults.
+func applySqliteDefaults(dsn string) string {
+	return applySQLiteWriterDefaults(dsn)
 }
 
 func splitSqliteDSN(dsn string) (base, query string) {


### PR DESCRIPTION
## Root cause

`_txlock=immediate` was in `sqliteSafeDefaults` and applied to **both** the reader pool (MaxOpenConns=10) and the dedicated writer. In SQLite, `BEGIN IMMEDIATE` acquires a RESERVED lock immediately — so all 10 reader connections competed for the same RESERVED lock under concurrent webhook load. This produced `"database table is locked: pipelines"` on `POST /api/hook` even after the dedicated-writer fix (#107).

The write queue serialises Go-level writes correctly. The contention was happening at the SQLite locking level, outside Go's visibility, between reader connections using `BEGIN IMMEDIATE` unnecessarily.

## Fix

Split reader and writer DSN defaults:

| | Reader pool | Writer |
|---|---|---|
| `_busy_timeout` | 30000 | 30000 |
| `_journal_mode` | WAL | WAL |
| `_synchronous` | NORMAL | NORMAL |
| `_txlock` | *(deferred, default)* | `immediate` |

Reader connections use SQLite's default deferred locking — they never write, so there's no upgrade-deadlock risk. `_txlock=immediate` is kept only on the single writer connection where it prevents the classic deferred-transaction upgrade-deadlock.

## Changes

- `sqlite_dsn.go`: split into `sqliteReaderDefaults` (no txlock) and `sqliteWriterDefaults` (with immediate). Backward-compat `applySqliteDefaults()` alias preserved for existing tests.
- `engine.go`: reader engine created with `applySQLiteReaderDefaults`, writer engine with `applySQLiteWriterDefaults`.

## Test plan

- [ ] `go test ./server/store/datastore/...` passes (pre-commit verified)
- [ ] Deploy pts.183 and monitor `/api/hook` error rate — `"database table is locked"` should stop appearing
- [ ] Verify under concurrent push webhooks (multiple repos pushing simultaneously) no lock errors in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)