### PR TITLE
fix: concurrent guard verifies owner pipeline status before aborting (#120)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh concurrent guard now verifies the owning pipeline is still active before aborting — a failed or killed pipeline leaves a stale pts-build-pipeline label on the VM; the old guard aborted on ANY running VM regardless of label, causing every subsequent pipeline to skip with a false "already in use" and leaving the compile step pending forever. Now checks owner pipeline status via the Woodpecker API and takes ownership when the labeled pipeline is no longer running (#120)
+
 - fix: SQLite reader pool no longer uses _txlock=immediate — applying BEGIN IMMEDIATE to reader connections caused all 10 pool connections to compete for the same RESERVED lock under concurrent webhook load, producing "database table is locked: pipelines" on POST /api/hook even after the dedicated-writer fix (#107). Reader DSN now uses deferred locking (SQLite default); _txlock=immediate is kept only on the single writer connection where it prevents upgrade-deadlocks (#114)
 
 - fix: pts-build.sh runs go build under `nice -n 10` — lowers CPU priority of the compile so the agent's WebSocket heartbeat goroutine is scheduled even under full-core saturation; prevents keepalive misses that drop the session and kill the compile (#115)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -15,21 +15,35 @@ WP_SERVER="d3ci42.peregrinetechsys.net"  # WebSocket via Caddy TLS (port 443)
 VERSION="v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}"
 
 # ── Concurrent-run guard ──
-# If pentest-dev-vm is already RUNNING, another pts-build pipeline is using it.
-# Abort cleanly — the in-flight pipeline will compile and stop the VM.
-# Multiple main pushes in quick succession (e.g. several PRs merging) each
-# trigger their own wake; only the first one should proceed.
+# If pentest-dev-vm is already RUNNING and owned by an ACTIVE pipeline, abort.
+# Multiple main pushes in quick succession each trigger their own wake; only
+# the first one should proceed. A stale label from a failed/killed pipeline is
+# NOT sufficient reason to abort — we must verify the owner is still running.
 CURRENT_STATUS=$(gcloud compute instances describe "${PENTEST_VM}" \
     --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
     --format="value(status)" 2>/dev/null || echo "UNKNOWN")
 if [ "${CURRENT_STATUS}" = "RUNNING" ]; then
     OWNER_PIPELINE=$(gcloud compute instances describe "${PENTEST_VM}" \
         --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
-        --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "unknown")
-    echo "==> ${PENTEST_VM} already RUNNING (owned by pipeline #${OWNER_PIPELINE}) — aborting."
-    echo "    This pipeline (#${CI_PIPELINE_NUMBER:-0}) will be skipped."
-    echo "    The in-flight pipeline will compile and deploy the latest code."
-    exit 0
+        --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "")
+    if [ -n "${OWNER_PIPELINE}" ] && [ "${OWNER_PIPELINE}" != "0" ]; then
+        # Verify the labeled pipeline is still active before deferring to it.
+        # A failed/killed pipeline leaves a stale label; don't abort for those.
+        OWNER_STATUS=$(curl -s --max-time 5 \
+            -H "Authorization: Bearer ${WOODPECKER_API_TOKEN}" \
+            "http://localhost:8000/api/repos/13/pipelines/${OWNER_PIPELINE}" \
+            2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" \
+            2>/dev/null || echo "unknown")
+        echo "==> ${PENTEST_VM} RUNNING — owner=#${OWNER_PIPELINE} status=${OWNER_STATUS}"
+        if [ "${OWNER_STATUS}" = "running" ] || [ "${OWNER_STATUS}" = "pending" ]; then
+            echo "    Active pipeline #${OWNER_PIPELINE} is compiling — skipping (#120)."
+            exit 0
+        else
+            echo "    Stale label from #${OWNER_PIPELINE} (${OWNER_STATUS}) — taking ownership."
+        fi
+    else
+        echo "==> ${PENTEST_VM} RUNNING with no owner label — taking ownership."
+    fi
 fi
 
 echo "==> Starting ${PENTEST_VM} for pts-build ${VERSION}..."


### PR DESCRIPTION
## Problem

The concurrent-run guard in `pts-wake.sh` aborted on **any** running `pentest-dev-vm`, regardless of whether the `pts-build-pipeline` label represented an active or dead pipeline. A failed or killed pipeline leaves a stale label on the VM. Every subsequent wake step would see `RUNNING` + label and exit 0 with \"already in use\", leaving the compile step pending forever with no agent.

Incident (2026-05-06): pipelines #197, #198, #199 all aborted with \"owned by pipeline #195\" even though #195 had already failed. Required manual VM stop to break the cycle.

## Fix

When the VM is RUNNING with an ownership label, check the labeled pipeline's status via the Woodpecker API:
- If owner is `running` or `pending` → abort (real concurrent use)  
- If owner is `failed`, `killed`, `success`, or unknown → take ownership and proceed

When no label is present → take ownership and proceed (VM was left running by something other than a pipeline).

## Test plan

- [ ] Trigger pts-build while another pipeline is actively compiling → should abort
- [ ] Trigger pts-build after a failed pipeline left stale label → should take ownership and proceed
- [ ] Trigger pts-build when VM is running with no label → should take ownership and proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)