### PR TITLE
fix: proactive agent token refresh — 24h duration + idle reconnect at 75% (#116)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: agent JWT token duration extended from 1h to 24h; proactive refresh goroutine exits cleanly at 75% of lifetime (18h) when idle so systemd restarts with fresh credentials before expiry — eliminates silent auth failures mid-pipeline and token-expiry kill on long-running local-backend agents (#116)
+
 - fix: pts-wake.sh combines agent binary check and agent start into one SSH session — consecutive connections from d3ci42 to pentest-dev-vm were triggering UFW limit 22/tcp (6 conn/30s); a 3s pause after the readiness poll + single combined session eliminates the extra connection that exceeded the rate limit (#119)
 
 - fix: pts-wake.sh concurrent guard now verifies the owning pipeline is still active before aborting — a failed or killed pipeline leaves a stale pts-build-pipeline label on the VM; the old guard aborted on ANY running VM regardless of label, causing every subsequent pipeline to skip with a false "already in use" and leaving the compile step pending forever. Now checks owner pipeline status via the Woodpecker API and takes ownership when the labeled pipeline is no longer running (#120)

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -299,6 +299,34 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 
 	log.Debug().Msgf("agent registered with ID %d", agentConfig.AgentID)
 
+	// Proactive token refresh (#116): exit cleanly at 75% of the token lifetime
+	// when idle so systemd restarts with a fresh registration before the token
+	// expires. Prevents silent auth failures mid-pipeline on long-running agents.
+	// agentTokenDuration must match server/rpc.jwtTokenDuration (24h).
+	const agentTokenDuration = 24 * time.Hour
+	tokenRefreshAt := time.Now().Add(agentTokenDuration * 3 / 4)
+	serviceWaitingGroup.Go(func() error {
+		select {
+		case <-agentCtx.Done():
+			return nil
+		case <-time.After(time.Until(tokenRefreshAt)):
+		}
+		// Only force reconnect when no tasks are in flight.
+		for counter.Running > 0 {
+			select {
+			case <-agentCtx.Done():
+				return nil
+			case <-time.After(30 * time.Second):
+			}
+		}
+		log.Info().Msg("proactive token refresh: no tasks running, reconnecting for fresh registration (#116)")
+		if agentConfigPath != "" {
+			_ = os.Remove(agentConfigPath)
+		}
+		log.Fatal().Msg("exiting for token refresh — systemd will restart with fresh credentials")
+		return nil
+	})
+
 	serviceWaitingGroup.Go(func() error {
 		for {
 			err := client.ReportHealth(grpcCtx)

--- a/server/rpc/jwt_manager.go
+++ b/server/rpc/jwt_manager.go
@@ -34,7 +34,14 @@ type AgentTokenClaims struct {
 	AgentID int64 `json:"agent_id"`
 }
 
-const jwtTokenDuration = 1 * time.Hour
+// jwtTokenDuration is the validity window for agent registration tokens.
+// 24h covers the longest expected CI job (cache restore + compile + deploy)
+// with substantial headroom. Agents re-register on each restart; expiry
+// only matters for long-running sessions (#116).
+//
+// The agent also runs a proactive refresh goroutine (cmd/agent/core/agent.go)
+// that forces a clean reconnect at 75% of this window when idle.
+const jwtTokenDuration = 24 * time.Hour
 
 // NewJWTManager returns a new JWT manager.
 func NewJWTManager(secretKey string) *JWTManager {


### PR DESCRIPTION
## Summary

- **`jwtTokenDuration` 1h → 24h** — the 1-hour window was close enough to pts-build compile time that a reconnect early in the session could cause expiry before the build finished. 24h covers any realistic CI job.
- **Proactive refresh goroutine** — fires at 75% of token lifetime (18h) when `counter.Running == 0`. Deletes `agent.conf` and calls `log.Fatal()` to trigger a clean systemd restart with fresh credentials. Does not interrupt in-flight tasks: polls every 30s until idle.

## Why log.Fatal() for refresh

The clean restart path is the same one used by the stale-conf fix (#101): systemd detects the exit, restarts the agent, and the agent re-registers with its existing agent ID from a freshly written `agent.conf`. No manual intervention needed.

## Notes

- `agentTokenDuration` constant in `agent.go` must stay in sync with `jwtTokenDuration` in `server/rpc/jwt_manager.go`. Both are 24h. A comment flags the dependency.
- Tests pass unmodified (`go test ./cmd/agent/core/... ./server/rpc/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)