### PR TITLE
fix: add ConnectTimeout=15 to PTS_SSH — prevents infinite hang on slow sshd boot

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh SSH adds ConnectTimeout=15 — without it, SSH hangs indefinitely if sshd accepts the TCP connection before finishing its banner exchange (kernel accepts port 22 before sshd is ready on boot); the readiness poll retry loop never fired because it was stuck mid-banner, not getting a connection refused
+
 - fix: agent JWT token duration extended from 1h to 24h; proactive refresh goroutine exits cleanly at 75% of lifetime (18h) when idle so systemd restarts with fresh credentials before expiry — eliminates silent auth failures mid-pipeline and token-expiry kill on long-running local-backend agents (#116)
 
 - fix: pts-wake.sh combines agent binary check and agent start into one SSH session — consecutive connections from d3ci42 to pentest-dev-vm were triggering UFW limit 22/tcp (6 conn/30s); a 3s pause after the readiness poll + single combined session eliminates the extra connection that exceeded the rate limit (#119)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -69,7 +69,7 @@ mkdir -p .deploy-ssh
 echo "$PTS_BUILD_SSH_KEY" > "$SSH_KEY"
 printf '\n' >> "$SSH_KEY"
 chmod 600 "$SSH_KEY"
-PTS_SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
+PTS_SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
 
 # Wait for SSH (up to 2 min)
 echo "==> Waiting for SSH..."


### PR DESCRIPTION
Pipeline #209 hung at 'Waiting for SSH' for 24+ minutes. Without `ConnectTimeout`, SSH blocks indefinitely if the kernel accepts the TCP connection on port 22 before sshd finishes banner exchange. The retry loop never fired — it was waiting for a banner, not seeing a connection refused. `ConnectTimeout=15` gives each readiness poll attempt a hard deadline so the loop works as designed.