### PR TITLE
fix: 10s boot pause + ConnectTimeout=15 — prevents SSH hang on slow sshd init

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh adds 10s boot pause before SSH readiness loop + ConnectTimeout=15 on all SSH calls — without the pause the kernel accepts port 22 before sshd has finished initialising; without ConnectTimeout SSH hangs indefinitely mid-banner and the retry loop never fires; pipeline #209 hung 24min at 'Waiting for SSH' until manually cancelled
+
 - fix: agent JWT token duration extended from 1h to 24h; proactive refresh goroutine exits cleanly at 75% of lifetime (18h) when idle so systemd restarts with fresh credentials before expiry — eliminates silent auth failures mid-pipeline and token-expiry kill on long-running local-backend agents (#116)
 
 - fix: pts-wake.sh combines agent binary check and agent start into one SSH session — consecutive connections from d3ci42 to pentest-dev-vm were triggering UFW limit 22/tcp (6 conn/30s); a 3s pause after the readiness poll + single combined session eliminates the extra connection that exceeded the rate limit (#119)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -69,7 +69,13 @@ mkdir -p .deploy-ssh
 echo "$PTS_BUILD_SSH_KEY" > "$SSH_KEY"
 printf '\n' >> "$SSH_KEY"
 chmod 600 "$SSH_KEY"
-PTS_SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
+PTS_SSH="ssh -i $SSH_KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=15 -o ServerAliveInterval=30 -o ServerAliveCountMax=10"
+
+# Brief boot pause — give sshd time to start before the first connection attempt.
+# Without this, the kernel accepts port 22 before sshd is ready; SSH hangs
+# waiting for a banner rather than getting connection refused, so ConnectTimeout
+# is the safety net but the pause makes it a non-issue in normal cases.
+sleep 10
 
 # Wait for SSH (up to 2 min)
 echo "==> Waiting for SSH..."


### PR DESCRIPTION
Pipeline #209 hung at 'Waiting for SSH' for 24+ minutes. Kernel accepts TCP port 22 before sshd finishes banner exchange on boot; SSH blocks mid-banner forever, retry loop never fires. Two-part fix: 10s sleep before the loop + ConnectTimeout=15 as safety net.