### PR TITLE
docs: note perms write queue gap (#126)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: permission middleware writes perms table outside the write queue — source of remaining SQLITE_BUSY on GET requests; affects pipeline restart API (#126)
+
 - fix: pts-wake.sh SSH adds ConnectTimeout=15 — without it, SSH hangs indefinitely if sshd accepts the TCP connection before finishing its banner exchange (kernel accepts port 22 before sshd is ready on boot); the readiness poll retry loop never fired because it was stuck mid-banner, not getting a connection refused
 
 - fix: agent JWT token duration extended from 1h to 24h; proactive refresh goroutine exits cleanly at 75% of lifetime (18h) when idle so systemd restarts with fresh credentials before expiry — eliminates silent auth failures mid-pipeline and token-expiry kill on long-running local-backend agents (#116)


### PR DESCRIPTION
Documents the remaining SQLITE_BUSY source found in production.