### PR TITLE
fix: revert jwtTokenDuration 24h → 1h — proper fix is heartbeat refresh (#116)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: revert jwtTokenDuration 24h → 1h; proper fix is heartbeat-based refresh via extend() (#116) — piggybacking a new token on the 30s keepalive avoids reconnection and keeps the attack window bounded by heartbeat interval rather than token lifetime
+
 - fix: permission middleware writes perms table outside the write queue — source of remaining SQLITE_BUSY on GET requests; affects pipeline restart API (#126)
 
 - fix: pts-wake.sh SSH adds ConnectTimeout=15 — without it, SSH hangs indefinitely if sshd accepts the TCP connection before finishing its banner exchange (kernel accepts port 22 before sshd is ready on boot); the readiness poll retry loop never fired because it was stuck mid-banner, not getting a connection refused

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -302,8 +302,8 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 	// Proactive token refresh (#116): exit cleanly at 75% of the token lifetime
 	// when idle so systemd restarts with a fresh registration before the token
 	// expires. Prevents silent auth failures mid-pipeline on long-running agents.
-	// agentTokenDuration must match server/rpc.jwtTokenDuration (24h).
-	const agentTokenDuration = 24 * time.Hour
+	// agentTokenDuration must match server/rpc.jwtTokenDuration (1h).
+	const agentTokenDuration = 1 * time.Hour
 	tokenRefreshAt := time.Now().Add(agentTokenDuration * 3 / 4)
 	serviceWaitingGroup.Go(func() error {
 		select {

--- a/server/rpc/jwt_manager.go
+++ b/server/rpc/jwt_manager.go
@@ -35,13 +35,11 @@ type AgentTokenClaims struct {
 }
 
 // jwtTokenDuration is the validity window for agent registration tokens.
-// 24h covers the longest expected CI job (cache restore + compile + deploy)
-// with substantial headroom. Agents re-register on each restart; expiry
-// only matters for long-running sessions (#116).
-//
-// The agent also runs a proactive refresh goroutine (cmd/agent/core/agent.go)
-// that forces a clean reconnect at 75% of this window when idle.
-const jwtTokenDuration = 24 * time.Hour
+// The permanent fix for expiry is heartbeat-based refresh via extend() (#116):
+// the server returns a new token on each extend() call; the agent stores it
+// transparently without reconnecting. Until that lands, the proactive-reconnect
+// goroutine in agent.go forces a clean restart at 75% of this window when idle.
+const jwtTokenDuration = 1 * time.Hour
 
 // NewJWTManager returns a new JWT manager.
 func NewJWTManager(secretKey string) *JWTManager {


### PR DESCRIPTION
24h widened the token compromise window. The correct fix is to piggyback a fresh token on the `extend()` keepalive call (every ~30s during active tasks) — no reconnect, no task interruption, attack window bounded by heartbeat interval. Until that proto change lands (see updated issue #116), the proactive-reconnect goroutine at 75% of the 1h window (45min) covers idle agents. Token lifetime back to 1h.