### PR TITLE
fix: write queue 256→1024, non-blocking serialize, HTTP 503 Retry-After on full

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: write queue depth 256 → 1024 + non-blocking serialize with HTTP 503 Retry-After on full — previously a saturated queue blocked caller goroutines silently; upstream HTTP timeouts surfaced as "database table is locked" and dropped webhooks. Now returns 503 Retry-After: 5 immediately; GitHub webhook delivery respects 503 and retries automatically
+
 - fix: revert jwtTokenDuration 24h → 1h; proper fix is heartbeat-based refresh via extend() (#116) — piggybacking a new token on the 30s keepalive avoids reconnection and keeps the attack window bounded by heartbeat interval rather than token lifetime
 
 - fix: permission middleware writes perms table outside the write queue — source of remaining SQLITE_BUSY on GET requests; affects pipeline restart API (#126)

--- a/server/api/helper.go
+++ b/server/api/helper.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -26,11 +27,30 @@ import (
 	"go.woodpecker-ci.org/woodpecker/v3/server/model"
 	"go.woodpecker-ci.org/woodpecker/v3/server/pipeline"
 	"go.woodpecker-ci.org/woodpecker/v3/server/store"
+	"go.woodpecker-ci.org/woodpecker/v3/server/store/datastore"
 	"go.woodpecker-ci.org/woodpecker/v3/server/store/types"
 )
 
+// retryAfterSeconds is the Retry-After value returned with 503 when the write
+// queue is full. GitHub webhook delivery retries on 503 and respects this header.
+const retryAfterSeconds = "5"
+
+// abort503IfOverloaded checks whether err is ErrWriteQueueFull and, if so,
+// responds with HTTP 503 + Retry-After and returns true. Callers should return
+// immediately when this returns true. Otherwise returns false (caller handles).
+func abort503IfOverloaded(c *gin.Context, err error) bool {
+	if !errors.Is(err, datastore.ErrWriteQueueFull) {
+		return false
+	}
+	c.Header("Retry-After", retryAfterSeconds)
+	c.String(http.StatusServiceUnavailable, fmt.Sprintf("server temporarily overloaded — retry in %s seconds", retryAfterSeconds))
+	return true
+}
+
 func handlePipelineErr(c *gin.Context, err error) {
 	switch {
+	case abort503IfOverloaded(c, err):
+		// 503 already sent
 	case errors.Is(err, &pipeline.ErrNotFound{}):
 		c.String(http.StatusNotFound, "%s", err)
 	case errors.Is(err, &pipeline.ErrBadRequest{}):
@@ -45,6 +65,9 @@ func handlePipelineErr(c *gin.Context, err error) {
 }
 
 func handleDBError(c *gin.Context, err error) {
+	if abort503IfOverloaded(c, err) {
+		return
+	}
 	if errors.Is(err, types.ErrRecordNotExist) {
 		c.AbortWithStatus(http.StatusNotFound)
 		return

--- a/server/store/datastore/write_queue.go
+++ b/server/store/datastore/write_queue.go
@@ -14,6 +14,12 @@
 
 package datastore
 
+import (
+	"fmt"
+
+	"github.com/rs/zerolog/log"
+)
+
 // writeQueue serializes all SQLite write operations through a single goroutine,
 // eliminating SQLITE_BUSY "database table is locked" errors under concurrent
 // write load. Without serialization, concurrent HTTP handlers (pipeline status
@@ -32,7 +38,11 @@ package datastore
 // Non-SQLite drivers: wq is nil and serialize() calls the fn directly, adding
 // zero overhead and requiring no driver-specific branching in callers.
 
-const writeQueueDepth = 256
+// writeQueueDepth is the buffer size of the write queue channel.
+// 1024 handles webhook bursts (many repos pushing simultaneously) without
+// stalling HTTP handlers. Previously 256 — silent blocking under burst
+// load caused upstream timeouts that surfaced as "database table is locked".
+const writeQueueDepth = 1024
 
 type writeOp struct {
 	fn     func() error
@@ -65,7 +75,14 @@ func (wq *writeQueue) close() {
 	close(wq.ops)
 }
 
+// ErrWriteQueueFull is returned by serialize when the queue is at capacity.
+// Callers should surface this as HTTP 503 with Retry-After so clients
+// (GitHub webhooks, scaler) back off and retry rather than piling up.
+var ErrWriteQueueFull = fmt.Errorf("write queue full — server overloaded, retry shortly")
+
 // serialize runs fn on the drain goroutine, blocking until it completes.
+// Returns ErrWriteQueueFull immediately (without blocking) if the queue is
+// at capacity — callers should return HTTP 503 Retry-After.
 // If wq is nil (non-SQLite driver), fn is called directly on the caller's
 // goroutine — semantics are identical, overhead is zero.
 func (wq *writeQueue) serialize(fn func() error) error {
@@ -73,6 +90,16 @@ func (wq *writeQueue) serialize(fn func() error) error {
 		return fn()
 	}
 	result := make(chan error, 1)
-	wq.ops <- writeOp{fn: fn, result: result}
+	op := writeOp{fn: fn, result: result}
+	select {
+	case wq.ops <- op:
+		// queued successfully
+	default:
+		log.Warn().
+			Int("queue_depth", len(wq.ops)).
+			Int("queue_cap", cap(wq.ops)).
+			Msg("SQLite write queue full — returning 503 to caller")
+		return ErrWriteQueueFull
+	}
 	return <-result
 }


### PR DESCRIPTION
Stops silent webhook drops when the write queue is saturated.

**Three changes:**
1. Queue depth 256 → 1024
2. `serialize()` uses non-blocking `select/default` — returns `ErrWriteQueueFull` immediately instead of blocking silently
3. `handlePipelineErr` and `handleDBError` return HTTP 503 `Retry-After: 5` on `ErrWriteQueueFull` — GitHub webhook delivery respects 503 and retries automatically

The root cause of dropped webhooks: queue saturation caused caller goroutines to block; HTTP timeouts fired; xorm reported 'database table is locked' from the stalled transaction context. This was invisible in logs. Now the queue logs a warn at capacity and the HTTP layer gets a retriable error instead of a silent drop.