### PR TITLE
fix: enforce backend=local only in agent.env on every deploy (#896)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: woodpecker-deploy.sh enforces WOODPECKER_AGENT_LABELS=backend=local in /etc/woodpecker/agent.env on every deploy — removes platform=linux which caused the d3ci42-local agent to claim GCP-fleet tasks, running npm/go builds on the same 2GB droplet as the server (OOM risk, contention, scaler mis-routing)
+
 - fix: write queue depth 256 → 1024 + non-blocking serialize with HTTP 503 Retry-After on full — previously a saturated queue blocked caller goroutines silently; upstream HTTP timeouts surfaced as "database table is locked" and dropped webhooks. Now returns 503 Retry-After: 5 immediately; GitHub webhook delivery respects 503 and retries automatically
 
 - fix: revert jwtTokenDuration 24h → 1h; proper fix is heartbeat-based refresh via extend() (#116) — piggybacking a new token on the 30s keepalive avoids reconnection and keeps the attack window bounded by heartbeat interval rather than token lifetime

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -177,6 +177,22 @@ find "${RELEASES_DIR}" -maxdepth 1 -mindepth 1 -type d | sort -r | \
     [ "${dir}" != "${current}" ] && rm -rf "${dir}" && echo "    Pruned: ${dir}"
 done
 
+# ── Enforce agent.env labels ──
+# The d3ci42-local agent must advertise ONLY backend=local — never platform=linux.
+# platform=linux causes it to compete with GCP VMs for regular CI tasks, running
+# them on the same 2GB droplet as the server (OOM risk, contention). Idempotent.
+AGENT_ENV="/etc/woodpecker/agent.env"
+if [ -f "${AGENT_ENV}" ]; then
+    if grep -q "platform=linux" "${AGENT_ENV}" 2>/dev/null; then
+        echo "    Fixing agent.env: removing platform=linux from WOODPECKER_AGENT_LABELS"
+        grep -v "^WOODPECKER_AGENT_LABELS=" "${AGENT_ENV}" > "${AGENT_ENV}.new"
+        echo "WOODPECKER_AGENT_LABELS=backend=local" >> "${AGENT_ENV}.new"
+        mv "${AGENT_ENV}.new" "${AGENT_ENV}"
+        systemctl restart woodpecker-agent || true
+        echo "    agent.env fixed + agent restarted"
+    fi
+fi
+
 # Remove pending marker
 gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
 


### PR DESCRIPTION
Idempotent check in `woodpecker-deploy.sh`: after each successful deploy, if `/etc/woodpecker/agent.env` contains `platform=linux` in `WOODPECKER_AGENT_LABELS`, it is stripped and `woodpecker-agent` is restarted. SSH-applied fix for today's incident; this codifies it so it self-heals on every future deploy.