### PR TITLE
debug: verbose SSH on combined session to diagnose exit-255 (#123)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- debug: pts-wake.sh combined SSH session uses LogLevel=VERBOSE to capture exact exit-255 failure reason (#123 — remove after diagnosis)
+
 - fix: woodpecker-deploy.sh enforces WOODPECKER_AGENT_LABELS=backend=local in /etc/woodpecker/agent.env on every deploy — removes platform=linux which caused the d3ci42-local agent to claim GCP-fleet tasks, running npm/go builds on the same 2GB droplet as the server (OOM risk, contention, scaler mis-routing)
 
 - fix: write queue depth 256 → 1024 + non-blocking serialize with HTTP 503 Retry-After on full — previously a saturated queue blocked caller goroutines silently; upstream HTTP timeouts surfaced as "database table is locked" and dropped webhooks. Now returns 503 Retry-After: 5 immediately; GitHub webhook delivery respects 503 and retries automatically

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -92,8 +92,12 @@ AGENT_SECRET="${WOODPECKER_AGENT_SECRET:?WOODPECKER_AGENT_SECRET must be set}"
 # UFW's rate limiter (limit 22/tcp = 6 conn/30s per source IP). Previously
 # these were two separate connections immediately following the readiness poll,
 # causing the third connection to be rejected mid-wake (#119).
+# Diagnostic: use verbose SSH for the combined session to capture exact failure reason.
+# Remove once SSH exit 255 root cause is confirmed (#123).
+PTS_SSH_VERBOSE="${PTS_SSH/ -o LogLevel=ERROR/ -o LogLevel=VERBOSE}"
+
 echo "==> Checking agent binary and starting Woodpecker agent on ${PENTEST_VM}..."
-AGENT_OUTPUT=$($PTS_SSH "root@${PENTEST_IP}" "
+AGENT_OUTPUT=$($PTS_SSH_VERBOSE "root@${PENTEST_IP}" "
     # ── Binary check ──
     AGENT_BIN=\$(ls /opt/woodpecker/woodpecker-agent-* 2>/dev/null | sort -V | tail -1 || echo '')
     if [ -z \"\$AGENT_BIN\" ]; then


### PR DESCRIPTION
Temporary diagnostic. Changes LogLevel=ERROR to LogLevel=VERBOSE for the combined binary-check + agent-start SSH call only. The verbose output goes to the Woodpecker step log, giving us the exact SSH error instead of silent exit 255. Remove after root cause confirmed.