### PR TITLE
debug: capture SSH stderr before set-e exits (#123)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- debug: pts-wake.sh captures SSH stderr to file before set -e can exit, prints it after — set -euo pipefail was killing the script before verbose output could print (#123 — remove after diagnosis)
+
 - debug: pts-wake.sh combined SSH session uses LogLevel=VERBOSE to capture exact exit-255 failure reason (#123 — remove after diagnosis)
 
 - fix: woodpecker-deploy.sh enforces WOODPECKER_AGENT_LABELS=backend=local in /etc/woodpecker/agent.env on every deploy — removes platform=linux which caused the d3ci42-local agent to claim GCP-fleet tasks, running npm/go builds on the same 2GB droplet as the server (OOM risk, contention, scaler mis-routing)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -97,7 +97,8 @@ AGENT_SECRET="${WOODPECKER_AGENT_SECRET:?WOODPECKER_AGENT_SECRET must be set}"
 PTS_SSH_VERBOSE="${PTS_SSH/ -o LogLevel=ERROR/ -o LogLevel=VERBOSE}"
 
 echo "==> Checking agent binary and starting Woodpecker agent on ${PENTEST_VM}..."
-AGENT_OUTPUT=$($PTS_SSH_VERBOSE "root@${PENTEST_IP}" "
+SSH_ERR_LOG="$(pwd)/.deploy-ssh/ssh-verbose.log"
+AGENT_OUTPUT=$($PTS_SSH_VERBOSE "root@${PENTEST_IP}" 2>"${SSH_ERR_LOG}" "
     # ── Binary check ──
     AGENT_BIN=\$(ls /opt/woodpecker/woodpecker-agent-* 2>/dev/null | sort -V | tail -1 || echo '')
     if [ -z \"\$AGENT_BIN\" ]; then
@@ -130,7 +131,12 @@ AGENT_OUTPUT=$($PTS_SSH_VERBOSE "root@${PENTEST_IP}" "
             cat /tmp/wp-agent.log 2>/dev/null || true
         fi
     fi
-")
+") || true  # capture exit code without triggering set -e; verbose log printed below
+# Print SSH verbose log regardless of exit code — captures error on exit 255
+if [ -s "${SSH_ERR_LOG}" ]; then
+    echo "==> SSH verbose log (for #123 diagnosis):"
+    cat "${SSH_ERR_LOG}"
+fi
 echo "    ${AGENT_OUTPUT}"
 
 AGENT_BIN=$(echo "${AGENT_OUTPUT}" | grep "^HAVE:" | cut -d: -f2-)


### PR DESCRIPTION
set -euo pipefail was killing the script before SSH verbose output could be printed. Redirects stderr to a temp file, uses || true on the assignment, prints the file after.