### PR TITLE
fix: pass AGENT_BIN as positional arg to inner bash-c — agent was silently not starting (#123)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh passes AGENT_BIN as positional arg to inner bash-c — single-quoted setsid bash -c string does not inherit outer shell variables; $AGENT_BIN was silently empty so exec ran with no binary and the agent never started (#123)
+
 - debug: pts-wake.sh captures SSH stderr to file before set -e can exit, prints it after — set -euo pipefail was killing the script before verbose output could print (#123 — remove after diagnosis)
 
 - debug: pts-wake.sh combined SSH session uses LogLevel=VERBOSE to capture exact exit-255 failure reason (#123 — remove after diagnosis)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -119,8 +119,8 @@ AGENT_OUTPUT=$($PTS_SSH_VERBOSE "root@${PENTEST_IP}" 2>"${SSH_ERR_LOG}" "
             export WOODPECKER_MAX_WORKFLOWS=1
             export WOODPECKER_GRPC_KEEPALIVE_TIME=10s
             export WOODPECKER_GRPC_KEEPALIVE_TIMEOUT=20s
-            exec \"\$AGENT_BIN\" agent
-        ' > /tmp/wp-agent.log 2>&1 </dev/null &
+            exec \"\$1\" agent
+        ' -- \"\$AGENT_BIN\" > /tmp/wp-agent.log 2>&1 </dev/null &
         AGENT_PID=\$!
         sleep 2
         if kill -0 \$AGENT_PID 2>/dev/null; then
@@ -170,8 +170,8 @@ if echo "${AGENT_OUTPUT}" | grep -q "^NEED_DOWNLOAD"; then
             export WOODPECKER_MAX_WORKFLOWS=1
             export WOODPECKER_GRPC_KEEPALIVE_TIME=10s
             export WOODPECKER_GRPC_KEEPALIVE_TIMEOUT=20s
-            exec \"\$AGENT_BIN\" agent
-        ' > /tmp/wp-agent.log 2>&1 </dev/null &
+            exec \"\$1\" agent
+        ' -- \"\$AGENT_BIN\" > /tmp/wp-agent.log 2>&1 </dev/null &
         sleep 2
         echo 'Downloaded and started: \$AGENT_BIN'
     "


### PR DESCRIPTION
Single-quoted `setsid bash -c '...'` doesn't inherit outer shell variables. `exec "\$AGENT_BIN" agent` resolved to `exec "" agent` silently — the agent never started, no `/tmp/wp-agent.log` was created, the registration poll timed out every time. Fix: `bash -c '... exec "\$1" agent' -- "\$AGENT_BIN"` passes the binary path as a positional arg.