### PR TITLE
fix: redirect GOCACHE/GOMODCACHE to 200GB data disk on pentest-dev-vm

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-build.sh redirects GOCACHE and GOMODCACHE to /mnt/pentest-data (200GB data disk) when available — the 30GB root partition fills up when the Woodpecker agent workspace sets HOME to a temp directory; gsutil rsync downloads 3.5GB of cache to root and is killed mid-transfer
+
 - fix: pts-wake.sh rewritten — agent now runs as systemd service on pentest-dev-vm (woodpecker-agent.service auto-starts on boot); wake step just starts the VM and polls the Woodpecker API for agent registration, no SSH required. Eliminates all SSH-based agent-start complexity and the exit-255 mystery class of bugs. TTL increased to 120min.
 
 - fix: pts-wake.sh replaces setsid bash-c with setsid env to start agent — bash -c inner shell couldn't exec the binary even with positional arg because the env vars are set by env directly on the process, no inner shell required

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -17,8 +17,17 @@ echo "==> pts-build: ${VERSION} (${SHA_SHORT})"
 
 # ── GCS build cache ──
 export PATH="/usr/local/go/bin:$PATH"
-GOCACHE="${HOME}/.cache/go-build"
-GOMODCACHE="${HOME}/go/pkg/mod"
+# Use the persistent 200GB data disk for build caches — the 30GB root
+# partition fills up when the agent's HOME is a temp workspace directory.
+DATA_DISK="/mnt/pentest-data"
+if [ -d "${DATA_DISK}" ] && [ "$(df -P "${DATA_DISK}" | awk 'NR==2{print $4}')" -gt 5000000 ]; then
+    GOCACHE="${DATA_DISK}/go-build-cache"
+    GOMODCACHE="${DATA_DISK}/go-mod-cache"
+    export GOTELEMETRY=off
+else
+    GOCACHE="${HOME}/.cache/go-build"
+    GOMODCACHE="${HOME}/go/pkg/mod"
+fi
 mkdir -p "${GOCACHE}" "${GOMODCACHE}"
 
 echo "==> Restoring GCS build cache..."


### PR DESCRIPTION
gsutil rsync downloads 3.5GB go-build cache to root partition when HOME is a temp workspace; kills the process mid-transfer. Fix: use `/mnt/pentest-data` (200GB, 124GB free) when available.