### PR TITLE
fix: pts-wake TTL reaper coordination and platform:linux label cleanup (#138)

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -4,7 +4,6 @@ when:
 
 labels:
   backend: local
-  platform: linux
 
 steps:
   - name: wake

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: pts-wake.sh sets ttl-override-min label so ttl-reaper-dev-vm.sh respects the 120min build window instead of its 90min default — reaper was stopping the VM mid-compile (#138)
+- fix: pts-wake.sh sets ttl-override-min=45 label so ttl-reaper-dev-vm.sh uses a 45min threshold instead of its 90min default — reaper was stopping abandoned VMs before the build could complete; 45min covers boot+cache+compile+cleanup (#138)
 - fix: pts-build.yaml removes platform:linux workflow label — d3ci42 local agent no longer advertises that label after PR #131 label cleanup (#138)
 
 - fix: pts-build.sh redirects GOCACHE and GOMODCACHE to /mnt/pentest-data (200GB data disk) when available — the 30GB root partition fills up when the Woodpecker agent workspace sets HOME to a temp directory; gsutil rsync downloads 3.5GB of cache to root and is killed mid-transfer

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh sets ttl-override-min label so ttl-reaper-dev-vm.sh respects the 120min build window instead of its 90min default — reaper was stopping the VM mid-compile (#138)
+- fix: pts-build.yaml removes platform:linux workflow label — d3ci42 local agent no longer advertises that label after PR #131 label cleanup (#138)
+
 - fix: pts-build.sh redirects GOCACHE and GOMODCACHE to /mnt/pentest-data (200GB data disk) when available — the 30GB root partition fills up when the Woodpecker agent workspace sets HOME to a temp directory; gsutil rsync downloads 3.5GB of cache to root and is killed mid-transfer
 
 - fix: pts-wake.sh rewritten — agent now runs as systemd service on pentest-dev-vm (woodpecker-agent.service auto-starts on boot); wake step just starts the VM and polls the Woodpecker API for agent registration, no SSH required. Eliminates all SSH-based agent-start complexity and the exit-255 mystery class of bugs. TTL increased to 120min.

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -42,11 +42,12 @@ echo "==> Starting ${PENTEST_VM} for pts-build v3.13.0-pts.${CI_PIPELINE_NUMBER:
 gcloud compute instances start "${PENTEST_VM}" \
     --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" --quiet
 
-# TTL label — safety net if cleanup workflow doesn't run
+# TTL labels — ttl-override-min tells ttl-reaper-dev-vm.sh to use this threshold
+# instead of its default 90min. ttl-expire-epoch is a secondary epoch-based marker.
 EXPIRE_EPOCH=$(( $(date +%s) + TTL_MINUTES * 60 ))
 gcloud compute instances add-labels "${PENTEST_VM}" \
     --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
-    --labels="ttl-expire-epoch=${EXPIRE_EPOCH},pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}"
+    --labels="ttl-expire-epoch=${EXPIRE_EPOCH},ttl-override-min=${TTL_MINUTES},pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}"
 echo "    TTL label set: expire in ${TTL_MINUTES}min (epoch ${EXPIRE_EPOCH})"
 
 # The woodpecker-agent.service on pentest-dev-vm auto-starts on boot.

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 PENTEST_PROJECT="peregrine-pentest-dev"
 PENTEST_ZONE="us-central1-a"
 PENTEST_VM="pentest-dev-vm"
-TTL_MINUTES=120  # generous budget: boot + cache restore + compile + deploy
+TTL_MINUTES=45  # boot (~3min) + cache restore (~10min) + compile (~20min) + slack
 
 WP_SERVER="d3ci42.peregrinetechsys.net"  # used only for reference
 


### PR DESCRIPTION
## Summary

- `pts-wake.sh`: sets `ttl-override-min=45` so `ttl-reaper-dev-vm.sh` uses a 45min threshold — reaper was stopping abandoned VMs (from killed pipelines) using the 90min default before the next active build could complete
- `pts-build.yaml`: removes `platform:linux` workflow label — d3ci42 local agent only advertises `backend=local` after PR #131; the extra label was preventing workflow dispatch

Closes #138

## Test plan

- [ ] Merge triggers pts-build pipeline
- [ ] pentest-dev-vm starts, agent registers, compile step runs
- [ ] VM stays alive for full build (reaper respects 45min ttl-override-min)
- [ ] pts.184+ deployed to d3ci42 on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)