### PR TITLE
feat: migrate pts-build to pts-build-vm in ci-runners-de (#140)

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -3,7 +3,8 @@ when:
     branch: main
 
 labels:
-  backend: local
+  platform: linux
+  tier: ondemand
 
 steps:
   - name: wake

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# woodpecker (fork)
+
+Peregrine fork of the Woodpecker CI/CD engine. Go 1.25 multi-package project: agent, CLI, server, web UI, RPC. Active fork — upstream patches cherry-picked selectively; Peregrine-specific fixes tracked with `pts-` prefix in branch names and issue references.
+
+## Fork relationship
+
+- Upstream: `woodpecker-ci/woodpecker`
+- This fork: `Peregrine-Technology-Systems/woodpecker`
+- Deployed to: `d3ci42.peregrinetechsys.net` (Woodpecker server) + GCP agent VMs
+- Active Peregrine issues tracked in this repo: `#27` (unknown /api paths return 200+HTML), `#39` (zombie defense), `#74` (pts-build wake pattern), `#77` (local agent stale agent.conf)
+
+## Structure
+
+```
+agent/       Woodpecker agent (connects to server, runs pipelines)
+cli/         `woodpecker-cli` command
+cmd/         entrypoints (agent, cli, server)
+server/      pipeline server + API + scheduler
+web/         React/TypeScript web UI
+rpc/         gRPC + protobuf definitions
+pipeline/    pipeline execution engine
+shared/      common types, config, utils
+
+.woodpecker/
+  pts-build.yaml         compile the fork on pentest-dev-vm
+  pts-ci.yaml            Peregrine-specific CI
+  pts-build-compile.yaml build step
+  pts-build-cleanup.yaml cleanup step
+```
+
+## Standards
+
+- All Peregrine-specific changes must be clearly marked — prefix commits with `[pts]` and reference a `pts-` issue
+- Never rebase onto upstream without verifying Peregrine patches survive
+- No `backend: local` in any pipeline step (global ban — see global CLAUDE.md)
+- Go standards: `go vet`, `gofmt`, `go test ./...`
+- Cross-repo: bugs surfacing in `peregrine-ci-scaler` or `ci-infrastructure` that originate here → fix here, file issues in consumers describing the impact
+- Do NOT drive-by PR upstream Woodpecker without explicit intent — changes here are fork-local unless deliberately upstreamed
+- When upstreaming, open a PR against `woodpecker-ci/woodpecker` from a branch that isolates just the upstream-ready change (no Peregrine-specific context)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-test.sh and pts-lint.sh use full Go binary path /usr/local/go/bin/go — /etc/profile.d/go.sh only runs for login shells; Woodpecker pipeline steps run non-login bash (#1343)
+
 - feat: migrate pts-build from pentest-dev-vm (peregrine-pentest-dev) to pts-build-vm (ci-runners-de) — dedicated build VM with no scan services; wake step now runs on GCP fleet (platform:linux, tier:ondemand) instead of backend:local (#140)
 
 - fix: pts-wake.sh sets ttl-override-min=45 label so ttl-reaper-dev-vm.sh uses a 45min threshold instead of its 90min default — reaper was stopping abandoned VMs before the build could complete; 45min covers boot+cache+compile+cleanup (#138)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: migrate pts-build from pentest-dev-vm (peregrine-pentest-dev) to pts-build-vm (ci-runners-de) — dedicated build VM with no scan services; wake step now runs on GCP fleet (platform:linux, tier:ondemand) instead of backend:local (#140)
+
 - fix: pts-wake.sh sets ttl-override-min=45 label so ttl-reaper-dev-vm.sh uses a 45min threshold instead of its 90min default — reaper was stopping abandoned VMs before the build could complete; 45min covers boot+cache+compile+cleanup (#138)
 - fix: pts-build.yaml removes platform:linux workflow label — d3ci42 local agent no longer advertises that label after PR #131 label cleanup (#138)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -23,7 +23,7 @@ Health endpoint: `http://localhost:8000/healthz` (returns 204 when healthy)
 
 ### Local Agent (`woodpecker-agent.service`)
 
-`pts-build.yaml` uses `backend: local` — steps run directly on d3ci42 as subprocesses rather than on a GCP agent VM. This requires a local `woodpecker-agent` process registered to the server.
+d3ci42 runs a local `woodpecker-agent` process for `backend: local` steps (internal tooling only — NOT pts-build as of #140).
 
 ```
 /etc/systemd/system/woodpecker-agent.service
@@ -33,82 +33,115 @@ Health endpoint: `http://localhost:8000/healthz` (returns 204 when healthy)
 
 Key agent config (`agent.env`):
 ```
-WOODPECKER_SERVER=localhost:9000        # gRPC direct — bypasses Caddy
+WOODPECKER_SERVER=localhost:9000   # gRPC direct — bypasses Caddy
 WOODPECKER_BACKEND=local
 WOODPECKER_MAX_WORKFLOWS=2
-WOODPECKER_AGENT_LABELS=backend=local,platform=linux  # platform=linux matches pts-build.yaml label selector
+WOODPECKER_AGENT_LABELS=backend=local  # NEVER add platform=linux — causes d3ci42 to steal GCP fleet tasks
 WOODPECKER_HOSTNAME=d3ci42-local
 ```
 
-`WOODPECKER_AGENT_SECRET` is injected from `/etc/woodpecker/secrets.env` via a separate `EnvironmentFile=` line. The service declares `Requires=woodpecker-server.service` so it starts after and restarts with the server.
+`WOODPECKER_AGENT_SECRET` is injected from `/etc/woodpecker/secrets.env` via a separate `EnvironmentFile=` line. The service declares `Wants=woodpecker-server.service` (not `Requires=` — agent should not cascade-stop the server on failure).
 
-**Incident 2026-05-05**: the infra#1403 migration created `woodpecker-server.service` but not `woodpecker-agent.service`. `backend: local` pipelines (pts-build) queued at `status: created` forever — the queue showed 0 workers with matching labels even with 4 VMs and 8 GCP agents registered (those agents have no `backend=local` label). Manually created the service; tracked for codification in peregrine-infrastructure#1465.
+**Stale agent.conf self-heal (#77)**: after a woodpecker-server restart that changes the JWT signing key or resets the agents DB, the agent's saved ID (`/etc/woodpecker/agent.conf`) becomes invalid. The agent detects `Unauthenticated` / `AgentID not found` / `sql: no rows` errors and calls `log.Fatal()` — the process exits with status 1, `Restart=on-failure` triggers, systemd restarts with no conf, and the agent re-registers fresh.
 
-**Operator note**: after a woodpecker binary update, `ExecStart=` in `woodpecker-agent.service` must be updated to point to the new agent binary. Not yet automated — tracked in #1465.
+### Build + Deploy Pipeline (three workflows, #74/#80/#140)
 
-**Stale agent.conf self-heal (#77)**: after a woodpecker-server restart that changes the JWT signing key or resets the agents DB, the agent's saved ID (`/etc/woodpecker/agent.conf`) becomes invalid. The agent detects `Unauthenticated` / `AgentID not found` / `sql: no rows` errors and calls `log.Fatal()` — the process exits with status 1, `Restart=on-failure` triggers, systemd restarts with no conf, and the agent re-registers fresh. Previous behaviour: the runner retry loop kept the process alive indefinitely with workers=0, requiring manual `rm /etc/woodpecker/agent.conf && systemctl restart woodpecker-agent`.
+Triggered on every push to `main`. Three decoupled Woodpecker workflows — wake/compile on pts-build-vm (GCP), cleanup on any GCP agent, deploy via standalone systemd timer on d3ci42.
 
-### Build + Deploy Pipeline (three workflows, #74/#80)
-
-Triggered on every push to `main`. Three decoupled Woodpecker workflows — compile on pentest-dev-vm, VM cleanup on d3ci42-local, deploy via standalone systemd timer:
-
-**Why three workflows / decoupled deploy:** pts-build.sh previously ran `systemctl restart woodpecker-server` inside the pipeline step. This restarted the server that the pentest-dev-vm agent was connected to, killing the gRPC connection and marking the pipeline killed before health check could run (self-kill loop). The deploy now happens entirely outside any Woodpecker pipeline.
+**Why three workflows / decoupled deploy:** pts-build.sh previously ran `systemctl restart woodpecker-server` inside the pipeline step. This restarted the server mid-pipeline, killing the gRPC connection and marking the pipeline killed before the health check could run (self-kill loop). The deploy now happens entirely outside any Woodpecker pipeline.
 
 ```
-Workflow 1 — pts-build.yaml (d3ci42-local, label: platform=linux, lightweight):
+Workflow 1 — pts-build.yaml (GCP agent, labels: platform:linux, tier:ondemand):
   pts-wake.sh:
-    1. gcloud instances start pentest-dev-vm
-    2. Set TTL label (ttl-expire-epoch) as safety net
-    3. SSH → pentest-dev: start woodpecker-agent with label agent=pts-build
-    4. Poll /api/agents until pentest-dev-vm registers (up to 100s)
+    1. gcloud instances start pts-build-vm (project: ci-runners-de)
+    2. Set ttl-override-min=45 + ttl-expire-epoch labels (reaper coordination)
+    3. Poll /api/agents until pts-build-vm registers (up to 180s)
 
-Workflow 2 — pts-build-compile.yaml (pentest-dev-vm agent, label: agent=pts-build):
+Workflow 2 — pts-build-compile.yaml (pts-build-vm agent, label: agent=pts-build):
   pts-build.sh:
-    5. GCS build cache restore
-    6. pnpm build (web UI)
-    7. CGO_ENABLED=1 go build woodpecker-server
-    8. CGO_ENABLED=0 go build woodpecker-agent
-    9. GCS build cache save
-   10. Upload binary + SHA256 to gs://ci-runners-de-build-cache/woodpecker-deploy/${VERSION}/
-   11. Write pending-deploy marker to gs://.../woodpecker-deploy/pending
-   12. GitHub Release + binary assets
-   13. ci-image-builder wake
+    4. GCS build cache restore (GOCACHE + GOMODCACHE from gs://ci-runners-de-build-cache/)
+    5. pnpm build (web UI)
+    6. CGO_ENABLED=1 go build woodpecker-server
+    7. CGO_ENABLED=0 go build woodpecker-agent
+    8. GCS build cache save
+    9. Upload binary + SHA256 to gs://ci-runners-de-build-cache/woodpecker-deploy/${VERSION}/
+   10. Write pending-deploy marker to gs://.../woodpecker-deploy/pending
+   11. GitHub Release + binary assets (woodpecker-server-linux-amd64, woodpecker-agent-linux-amd64)
+   12. Write job to gs://ci-runners-de-image-builder-state/jobs/ + start ci-image-builder
 
-Workflow 3 — pts-build-cleanup.yaml (d3ci42-local, always runs):
+Workflow 3 — pts-build-cleanup.yaml (GCP agent, always runs):
   pts-cleanup.sh:
-   14. gcloud instances stop pentest-dev-vm
-   15. Remove TTL labels
+   13. gcloud instances stop pts-build-vm
   pts-notify.sh:
-   16. Slack notify (success/failure of compile workflow)
+   14. Slack notify (success/failure of compile workflow)
 
 Separately on d3ci42 — woodpecker-deploy.service (systemd timer, every 30s):
   woodpecker-deploy.sh:
-   17. Poll GCS for pending-deploy marker; exit 0 if absent
-   18. Download binary, verify SHA256
-   19. Stage release: mkdir, cp, chmod
-   20. ln -sfn releases/${VERSION} current  (atomic symlink)
-   21. systemctl restart woodpecker-server
-   22. 90s health check: poll /healthz until version matches or timeout
-   23. On failure: rollback symlink + systemctl restart + Slack alert
-   24. On success: prune old releases (keep 3), remove pending marker, Slack success
+   15. Poll GCS for pending-deploy marker; exit 0 if absent
+   16. Download binary, verify SHA256
+   17. Stage release: mkdir, cp, chmod
+   18. ln -sfn releases/${VERSION} current  (atomic symlink)
+   19. systemctl restart woodpecker-server
+   20. 90s health check: poll /healthz until version matches or timeout
+   21. On failure: rollback symlink + systemctl restart + Slack alert
+   22. On success: prune old releases (keep 3), remove pending marker, Slack success
 ```
 
+**pts-build-vm** (`ci-runners-de`, zone `us-central1-a`):  
+Dedicated GCE VM with the `pts-build` image family baked by ci-image-builder. Contains Go + gcc + pnpm toolchain. Stopped when idle; started by pts-wake.sh on each build. woodpecker-agent.service auto-starts on boot with label `agent=pts-build`.
+
 **GCS build cache** (`gs://ci-runners-de-build-cache`):  
-Restored at step 5, saved after step 9. Warm cache reduces compile from ~8 min to ~1–2 min.
+Restored at step 4, saved after step 8. No persistent disk on pts-build-vm — cache lives entirely in GCS. Warm cache reduces compile from ~20 min to ~2 min.
 
 **GCS deploy path** (`gs://ci-runners-de-build-cache/woodpecker-deploy/`):  
-Binary and SHA256 at `${VERSION}/woodpecker-server{,.sha256}`. Pending marker at `pending` (content: `${VERSION}\n${COMMIT_SHA}\n${PIPELINE_NUM}`). The marker is deleted after a successful deploy or a failed deploy (to prevent infinite retry loops).
+Binary and SHA256 at `${VERSION}/woodpecker-server{,.sha256}`. Pending marker at `pending` (content: `${VERSION}\n${COMMIT_SHA}\n${PIPELINE_NUM}`). Deleted after successful or failed deploy.
 
-**TTL safety net:** pts-wake.sh writes `ttl-expire-epoch` label on pentest-dev-vm at start. If pts-build-cleanup fails to stop the VM, the TTL reaper on d3ci42 catches it.
+**TTL coordination:** pts-wake.sh sets `ttl-override-min=45` on pts-build-vm. The `ttl-reaper-dev-vm.sh` timer on d3ci42 reads this label and keeps the VM alive for 45 min — enough for boot + cache restore + compile + cleanup.
 
 **woodpecker-deploy.sh operational notes:**  
 - Runs as `woodpecker-deploy.service` (oneshot) fired by `woodpecker-deploy.timer` (every 30s)  
 - Exclusive flock at `/tmp/woodpecker-deploy.lock` prevents concurrent runs  
 - Sources `/etc/woodpecker/secrets.env` for `SLACK_WEBHOOK_URL`  
-- Rollback target: `readlink -f /opt/woodpecker/server/current` before symlink swap  
-- Codification tracked in peregrine-infrastructure#1511
+- Rollback target: `readlink -f /opt/woodpecker/server/current` before symlink swap
 
-**Reference incident (2026-05-05):** pts-build self-killed by restarting woodpecker-server mid-pipeline. Binary uploaded to GCS but symlink never swapped because health check step never ran.
+---
+
+### pts-build-vm Image Rebuild Runbook
+
+The `pts-build` Packer image bakes in the Go/gcc/pnpm toolchain and a woodpecker-agent binary. **Routine woodpecker server builds do NOT require an image rebuild** — the agent on pts-build-vm just picks up pipeline steps regardless of which server version is being compiled.
+
+Rebuild the pts-build image when:
+- `libsqlite3-dev`, `pnpm`, or Go version need updating
+- The woodpecker-agent binary has breaking gRPC protocol changes incompatible with the current pts-build-vm agent
+
+**Trigger a rebuild:**
+```bash
+WP_AGENT_VERSION="v3.13.0-pts.NNN"   # agent version to bake in
+REQUEST_ID=$(python3 -c "import uuid; print(str(uuid.uuid4()))")
+JOB_JSON="{\"request_id\":\"${REQUEST_ID}\",\"build_type\":\"pts-build\",\"wp_agent_version\":\"${WP_AGENT_VERSION}\",\"triggered_by\":\"manual\"}"
+
+echo "$JOB_JSON" | gsutil -q cp - "gs://ci-runners-de-image-builder-state/jobs/${REQUEST_ID}.json"
+gcloud compute instances start ci-image-builder \
+  --zone=us-central1-a --project=ci-runners-de --quiet
+
+echo "Job submitted: ${REQUEST_ID}"
+```
+
+ci-image-builder's `bootstrap.sh` downloads `woodpecker-agent-linux-amd64` from the fork's GitHub Release for `$WP_AGENT_VERSION`, runs `packer build pts-build.pkr.hcl`, and the new image lands in the `pts-build` GCE family. The builder stops itself on completion.
+
+**Check build progress:**
+```bash
+# Watch build logs
+gsutil ls "gs://ci-runners-de-image-builder-state/logs/" | sort | tail -5
+gsutil cat "gs://ci-runners-de-image-builder-state/logs/LATEST_LOG_FILE"
+
+# Confirm new image in pts-build family
+gcloud compute images list \
+  --project=ci-runners-de \
+  --filter="family=pts-build" \
+  --sort-by=~creationTimestamp --limit=3 \
+  --format="table(name,status,creationTimestamp)"
+```
 
 ### `Dockerfile.archived`
 

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # pts-build.sh — compile woodpecker and publish to GCS for deployment.
-# Runs natively on pentest-dev-vm via the pts-build Woodpecker agent (#74).
+# Runs natively on pts-build-vm via the pts-build Woodpecker agent (#140).
 # Does NOT touch d3ci42 directly — binary is placed in GCS and a pending-deploy
 # marker is written. woodpecker-deploy.sh on d3ci42 picks it up via systemd timer.
 #
@@ -19,7 +19,7 @@ echo "==> pts-build: ${VERSION} (${SHA_SHORT})"
 export PATH="/usr/local/go/bin:$PATH"
 # Use the persistent 200GB data disk for build caches — the 30GB root
 # partition fills up when the agent's HOME is a temp workspace directory.
-DATA_DISK="/mnt/pentest-data"
+DATA_DISK="/mnt/pts-build-data"
 if [ -d "${DATA_DISK}" ] && [ "$(df -P "${DATA_DISK}" | awk 'NR==2{print $4}')" -gt 5000000 ]; then
     GOCACHE="${DATA_DISK}/go-build-cache"
     GOMODCACHE="${DATA_DISK}/go-mod-cache"

--- a/scripts/woodpecker/pts-lint.sh
+++ b/scripts/woodpecker/pts-lint.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Packer puts Go at /usr/local/go/bin; /etc/profile.d/go.sh adds it to PATH for
-# login shells only. This script runs under non-login bash, so export directly.
-export PATH="/usr/local/go/bin:$PATH"
+GO=/usr/local/go/bin/go
 
 echo "==> Running go vet on Peregrine packages..."
 
@@ -16,6 +14,6 @@ PACKAGES=(
   go.woodpecker-ci.org/woodpecker/v3/server/queue/...
 )
 
-go vet "${PACKAGES[@]}"
+"${GO}" vet "${PACKAGES[@]}"
 
 echo "==> Lint passed"

--- a/scripts/woodpecker/pts-test.sh
+++ b/scripts/woodpecker/pts-test.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Packer puts Go at /usr/local/go/bin; /etc/profile.d/go.sh adds it to PATH for
-# login shells only. This script runs under non-login bash, so export directly.
-export PATH="/usr/local/go/bin:$PATH"
+GO=/usr/local/go/bin/go
 
 echo "==> Running tests on Peregrine plugin packages..."
 
@@ -25,6 +23,6 @@ if [ -n "$HEAD_TREE" ] && [ "$HEAD_TREE" = "$MAIN_TREE" ]; then
   exit 0
 fi
 
-go test -v -count=1 "${PACKAGES[@]}"
+"${GO}" test -v -count=1 "${PACKAGES[@]}"
 
 echo "==> Tests passed"

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -1,24 +1,25 @@
 #!/usr/bin/env bash
-# pts-wake.sh — start pentest-dev-vm and wait for the Woodpecker agent to register.
+# pts-wake.sh — start pts-build-vm and wait for the Woodpecker agent to register.
 # The agent (woodpecker-agent.service) auto-starts via systemd on VM boot.
 # No SSH required — just start the VM and poll the Woodpecker API.
+# Runs on any GCP agent (platform:linux, tier:ondemand) — not backend:local (#140).
 set -euo pipefail
 
-PENTEST_PROJECT="peregrine-pentest-dev"
-PENTEST_ZONE="us-central1-a"
-PENTEST_VM="pentest-dev-vm"
+PTS_BUILD_PROJECT="ci-runners-de"
+PTS_BUILD_ZONE="us-central1-a"
+PTS_BUILD_VM="pts-build-vm"
 TTL_MINUTES=45  # boot (~3min) + cache restore (~10min) + compile (~20min) + slack
 
 WP_SERVER="d3ci42.peregrinetechsys.net"  # used only for reference
 
 # ── Concurrent-run guard ──
-# If pentest-dev-vm is already RUNNING and owned by an ACTIVE pipeline, abort.
-CURRENT_STATUS=$(gcloud compute instances describe "${PENTEST_VM}" \
-    --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+# If pts-build-vm is already RUNNING and owned by an ACTIVE pipeline, abort.
+CURRENT_STATUS=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
+    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
     --format="value(status)" 2>/dev/null || echo "UNKNOWN")
 if [ "${CURRENT_STATUS}" = "RUNNING" ]; then
-    OWNER_PIPELINE=$(gcloud compute instances describe "${PENTEST_VM}" \
-        --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+    OWNER_PIPELINE=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
+        --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
         --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "")
     if [ -n "${OWNER_PIPELINE}" ] && [ "${OWNER_PIPELINE}" != "0" ]; then
         OWNER_STATUS=$(curl -s --max-time 5 \
@@ -26,7 +27,7 @@ if [ "${CURRENT_STATUS}" = "RUNNING" ]; then
             "http://localhost:8000/api/repos/13/pipelines/${OWNER_PIPELINE}" \
             2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" \
             2>/dev/null || echo "unknown")
-        echo "==> ${PENTEST_VM} RUNNING — owner=#${OWNER_PIPELINE} status=${OWNER_STATUS}"
+        echo "==> ${PTS_BUILD_VM} RUNNING — owner=#${OWNER_PIPELINE} status=${OWNER_STATUS}"
         if [ "${OWNER_STATUS}" = "running" ] || [ "${OWNER_STATUS}" = "pending" ]; then
             echo "    Active pipeline #${OWNER_PIPELINE} is compiling — skipping (#120)."
             exit 0
@@ -34,25 +35,25 @@ if [ "${CURRENT_STATUS}" = "RUNNING" ]; then
             echo "    Stale label from #${OWNER_PIPELINE} (${OWNER_STATUS}) — taking ownership."
         fi
     else
-        echo "==> ${PENTEST_VM} RUNNING with no owner label — taking ownership."
+        echo "==> ${PTS_BUILD_VM} RUNNING with no owner label — taking ownership."
     fi
 fi
 
-echo "==> Starting ${PENTEST_VM} for pts-build v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}..."
-gcloud compute instances start "${PENTEST_VM}" \
-    --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" --quiet
+echo "==> Starting ${PTS_BUILD_VM} for pts-build v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}..."
+gcloud compute instances start "${PTS_BUILD_VM}" \
+    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet
 
 # TTL labels — ttl-override-min tells ttl-reaper-dev-vm.sh to use this threshold
 # instead of its default 90min. ttl-expire-epoch is a secondary epoch-based marker.
 EXPIRE_EPOCH=$(( $(date +%s) + TTL_MINUTES * 60 ))
-gcloud compute instances add-labels "${PENTEST_VM}" \
-    --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+gcloud compute instances add-labels "${PTS_BUILD_VM}" \
+    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
     --labels="ttl-expire-epoch=${EXPIRE_EPOCH},ttl-override-min=${TTL_MINUTES},pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}"
 echo "    TTL label set: expire in ${TTL_MINUTES}min (epoch ${EXPIRE_EPOCH})"
 
-# The woodpecker-agent.service on pentest-dev-vm auto-starts on boot.
+# The woodpecker-agent.service on pts-build-vm auto-starts on boot.
 # Poll the Woodpecker API until it registers (up to 3 min — accounts for boot time).
-echo "==> Waiting for pentest-dev-vm agent to register with Woodpecker..."
+echo "==> Waiting for pts-build-vm agent to register with Woodpecker..."
 for i in $(seq 1 36); do
     FOUND=$(curl -sf --max-time 5 "https://d3ci42.peregrinetechsys.net/api/agents" \
         -H "Authorization: Bearer ${WOODPECKER_API_TOKEN}" 2>/dev/null | \
@@ -60,15 +61,15 @@ for i in $(seq 1 36); do
 import sys,json,time
 agents=json.load(sys.stdin)
 now=int(time.time())
-found=[a for a in agents if a.get('name','')=='pentest-dev-vm' and now-a.get('last_contact',0)<60]
+found=[a for a in agents if a.get('name','')=='pts-build-vm' and now-a.get('last_contact',0)<60]
 print(len(found))
 " 2>/dev/null || echo 0)
     if [ "${FOUND:-0}" -gt 0 ]; then
-        echo "    pentest-dev-vm agent registered (attempt ${i})"
+        echo "    pts-build-vm agent registered (attempt ${i})"
         exit 0
     fi
     echo "    waiting... (attempt ${i}/36, $((i*5))s elapsed)"
     sleep 5
 done
-echo "ERROR: pentest-dev-vm agent did not register within 180s"
+echo "ERROR: pts-build-vm agent did not register within 180s"
 exit 1


### PR DESCRIPTION
## Summary

- `pts-wake.sh`: targets `pts-build-vm` in `ci-runners-de` instead of `pentest-dev-vm` in `peregrine-pentest-dev`
- `pts-build.yaml`: wake step runs on GCP fleet (`platform:linux, tier:ondemand`) — removes `backend:local` which is banned per global CLAUDE.md
- `pts-build.sh`: updates `DATA_DISK` path and comment for new VM

## Why

pentest-dev-vm has scan services that terminate the VM within ~3 minutes of boot, preventing the compile step from ever running. pts-build-vm is a dedicated build host in ci-runners-de with no interference.

Closes #140

## Test plan

- [ ] Merge triggers pts-build pipeline #256+
- [ ] Wake step runs on a GCP agent (not d3ci42 local)
- [ ] pts-build-vm starts, agent registers, compile step runs
- [ ] Binary uploaded to GCS, deployed to d3ci42

🤖 Generated with [Claude Code](https://claude.com/claude-code)