### PR TITLE
fix: enforce Wants= in woodpecker-agent.service on every deploy (#112)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: woodpecker-deploy.sh enforces Wants= (not Requires=) in woodpecker-agent.service on every deploy — Requires= cascades server restarts to the agent, killing in-flight pipelines (#112)
+
 - fix: pts-test.sh and pts-lint.sh use full Go binary path /usr/local/go/bin/go — /etc/profile.d/go.sh only runs for login shells; Woodpecker pipeline steps run non-login bash (#1343)
 
 - feat: migrate pts-build from pentest-dev-vm (peregrine-pentest-dev) to pts-build-vm (ci-runners-de) — dedicated build VM with no scan services; wake step now runs on GCP fleet (platform:linux, tier:ondemand) instead of backend:local (#140)

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -177,6 +177,17 @@ find "${RELEASES_DIR}" -maxdepth 1 -mindepth 1 -type d | sort -r | \
     [ "${dir}" != "${current}" ] && rm -rf "${dir}" && echo "    Pruned: ${dir}"
 done
 
+# ── Enforce Wants= (not Requires=) in woodpecker-agent.service ──
+# Requires= cascades server restarts to the agent, killing in-flight pipelines.
+# Wants= starts the agent after the server but never stops it on server restart (#112).
+AGENT_UNIT="/etc/systemd/system/woodpecker-agent.service"
+if [ -f "${AGENT_UNIT}" ] && grep -q "^Requires=woodpecker-server" "${AGENT_UNIT}" 2>/dev/null; then
+    echo "    Fixing woodpecker-agent.service: Requires= → Wants="
+    sed -i 's/^Requires=woodpecker-server/Wants=woodpecker-server/' "${AGENT_UNIT}"
+    systemctl daemon-reload
+    echo "    woodpecker-agent.service fixed (daemon-reloaded)"
+fi
+
 # ── Enforce agent.env labels ──
 # The d3ci42-local agent must advertise ONLY backend=local — never platform=linux.
 # platform=linux causes it to compete with GCP VMs for regular CI tasks, running


### PR DESCRIPTION
## Summary

- `woodpecker-deploy.sh` now checks for `Requires=woodpecker-server` in `woodpecker-agent.service` and rewrites to `Wants=` + `systemctl daemon-reload` if found. Idempotent.

## Why

`Requires=` cascades server restarts to the agent — every deploy or healthcheck restart killed in-flight pipelines. `Wants=` starts the agent after the server but never stops it on server restart.

Already SSH-applied manually on d3ci42 on 2026-05-06. This codifies it so it's enforced on every future deploy.

Closes #112

## Test plan
- [ ] CI passes
- [ ] Merge triggers pts-build pipeline
- [ ] After deploy: verify `grep Wants /etc/systemd/system/woodpecker-agent.service` on d3ci42

🤖 Generated with [Claude Code](https://claude.com/claude-code)