### PR TITLE
fix: migrate pts-build-cleanup to pts-build-vm (#140)

### DIFF
--- a/.woodpecker/pts-build-cleanup.yaml
+++ b/.woodpecker/pts-build-cleanup.yaml
@@ -5,7 +5,7 @@ when:
 
 labels:
   platform: linux
-  backend: local
+  tier: ondemand
 
 depends_on: [pts-build-compile]
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-build-cleanup.yaml and pts-cleanup.sh migrated to pts-build-vm (ci-runners-de) — cleanup now runs on GCP fleet agent (platform:linux, tier:ondemand), not d3ci42 local; also removes ttl-override-min label on cleanup (#140)
+
 - fix: woodpecker-deploy.sh enforces Wants= (not Requires=) in woodpecker-agent.service on every deploy — Requires= cascades server restarts to the agent, killing in-flight pipelines (#112)
 
 - fix: pts-test.sh and pts-lint.sh use full Go binary path /usr/local/go/bin/go — /etc/profile.d/go.sh only runs for login shells; Woodpecker pipeline steps run non-login bash (#1343)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: woodpecker-deploy.sh enforces Wants= (not Requires=) in woodpecker-agent.service on every deploy — Requires= cascades server restarts to the agent, killing in-flight pipelines (#112)
+
 - fix: pts-test.sh and pts-lint.sh use full Go binary path /usr/local/go/bin/go — /etc/profile.d/go.sh only runs for login shells; Woodpecker pipeline steps run non-login bash (#1343)
 
 - feat: migrate pts-build from pentest-dev-vm (peregrine-pentest-dev) to pts-build-vm (ci-runners-de) — dedicated build VM with no scan services; wake step now runs on GCP fleet (platform:linux, tier:ondemand) instead of backend:local (#140)

--- a/scripts/woodpecker/pts-cleanup.sh
+++ b/scripts/woodpecker/pts-cleanup.sh
@@ -1,34 +1,34 @@
 #!/usr/bin/env bash
-# pts-cleanup.sh — stop pentest-dev-vm and remove TTL labels.
-# Runs on d3ci42-local after pts-build-compile completes (success or failure).
+# pts-cleanup.sh — stop pts-build-vm and remove TTL labels.
+# Runs on a GCP fleet agent after pts-build-compile completes (success or failure).
 # Deploy of woodpecker-server is handled separately by woodpecker-deploy.sh
 # via systemd timer — NOT here. Decoupled to avoid the self-kill problem (#74).
 set -euo pipefail
 
-PENTEST_PROJECT="peregrine-pentest-dev"
-PENTEST_ZONE="us-central1-a"
-PENTEST_VM="pentest-dev-vm"
+PTS_BUILD_PROJECT="ci-runners-de"
+PTS_BUILD_ZONE="us-central1-a"
+PTS_BUILD_VM="pts-build-vm"
 
 # Mutex guard: the wake step labels the VM with pts-build-pipeline=N.
 # If a newer pipeline has already claimed the VM, skip the stop — we'd
 # be killing a concurrent wake step mid-boot (#109).
 MY_PIPELINE="${CI_PIPELINE_NUMBER:-0}"
-OWNER_PIPELINE=$(gcloud compute instances describe "${PENTEST_VM}" \
-    --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
+OWNER_PIPELINE=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
+    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
     --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "")
 echo "==> Mutex check: my pipeline=#${MY_PIPELINE} owner=#${OWNER_PIPELINE:-unknown}"
 
 if [ -n "${OWNER_PIPELINE}" ] && [ "${OWNER_PIPELINE}" -gt "${MY_PIPELINE}" ] 2>/dev/null; then
     echo "    VM owned by newer pipeline #${OWNER_PIPELINE} — skipping stop (superseded)"
 else
-    echo "==> Stopping ${PENTEST_VM}..."
-    gcloud compute instances stop "${PENTEST_VM}" \
-        --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" --quiet 2>/dev/null && \
+    echo "==> Stopping ${PTS_BUILD_VM}..."
+    gcloud compute instances stop "${PTS_BUILD_VM}" \
+        --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet 2>/dev/null && \
         echo "    stopped" || echo "    ⚠️  stop failed or VM already stopped (non-fatal)"
 
     echo "==> Removing TTL labels..."
-    gcloud compute instances remove-labels "${PENTEST_VM}" \
-        --zone="${PENTEST_ZONE}" --project="${PENTEST_PROJECT}" \
-        --labels=ttl-expire-epoch,pts-build-pipeline 2>/dev/null && \
+    gcloud compute instances remove-labels "${PTS_BUILD_VM}" \
+        --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
+        --labels=ttl-expire-epoch,ttl-override-min,pts-build-pipeline 2>/dev/null && \
         echo "    labels removed" || echo "    ⚠️  label removal failed (non-fatal)"
 fi

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -177,6 +177,17 @@ find "${RELEASES_DIR}" -maxdepth 1 -mindepth 1 -type d | sort -r | \
     [ "${dir}" != "${current}" ] && rm -rf "${dir}" && echo "    Pruned: ${dir}"
 done
 
+# ── Enforce Wants= (not Requires=) in woodpecker-agent.service ──
+# Requires= cascades server restarts to the agent, killing in-flight pipelines.
+# Wants= starts the agent after the server but never stops it on server restart (#112).
+AGENT_UNIT="/etc/systemd/system/woodpecker-agent.service"
+if [ -f "${AGENT_UNIT}" ] && grep -q "^Requires=woodpecker-server" "${AGENT_UNIT}" 2>/dev/null; then
+    echo "    Fixing woodpecker-agent.service: Requires= → Wants="
+    sed -i 's/^Requires=woodpecker-server/Wants=woodpecker-server/' "${AGENT_UNIT}"
+    systemctl daemon-reload
+    echo "    woodpecker-agent.service fixed (daemon-reloaded)"
+fi
+
 # ── Enforce agent.env labels ──
 # The d3ci42-local agent must advertise ONLY backend=local — never platform=linux.
 # platform=linux causes it to compete with GCP VMs for regular CI tasks, running


### PR DESCRIPTION
## Summary

Missed in PR #141 — the cleanup workflow and script still referenced pentest-dev-vm.

- `pts-build-cleanup.yaml`: `backend: local` → `platform: linux, tier: ondemand` (runs on GCP fleet, not d3ci42)
- `pts-cleanup.sh`: all references updated to `pts-build-vm` in `ci-runners-de`; also removes `ttl-override-min` label on cleanup

Closes the migration started in #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)