### PR TITLE
fix: pts-wake.sh agent poll uses startswith for FQDN hostname (#140)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh agent poll uses startswith('pts-build-vm') — GCE registers with FQDN (pts-build-vm.us-central1-a.c.ci-runners-de.internal), exact match never fires (#140)
+
 - fix: pts-build-cleanup.yaml — remove stop-vm step (pts-build-vm self-stops after compile); update labels to platform:linux, tier:ondemand; delete pts-cleanup.sh (#140)
 
 - fix: pts-test.sh and pts-lint.sh use full Go binary path /usr/local/go/bin/go — /etc/profile.d/go.sh only runs for login shells; Woodpecker pipeline steps run non-login bash (#1343)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -61,7 +61,7 @@ for i in $(seq 1 36); do
 import sys,json,time
 agents=json.load(sys.stdin)
 now=int(time.time())
-found=[a for a in agents if a.get('name','')=='pts-build-vm' and now-a.get('last_contact',0)<60]
+found=[a for a in agents if a.get('name','').startswith('pts-build-vm') and now-a.get('last_contact',0)<60]
 print(len(found))
 " 2>/dev/null || echo 0)
     if [ "${FOUND:-0}" -gt 0 ]; then


### PR DESCRIPTION
## Problem

GCE VMs register with their internal FQDN: `pts-build-vm.us-central1-a.c.ci-runners-de.internal`

pts-wake.sh was checking `a.get('name','') == 'pts-build-vm'` — exact match never fires.

## Fix

Use `startswith('pts-build-vm')` so the poll detects the agent regardless of domain suffix.

Closes part of #140 (registration detection). The agent secret / label issue is tracked separately via infra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)