### PR TITLE
perf: restore web UI dist/ from GCS cache in pts-build.sh

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- perf: pts-build.sh restores web UI dist/ from GCS cache instead of running pnpm on every compile — UI never changes so pnpm was wasted time; fallback to pnpm build only on cold cache, saves result back to GCS
+
 - fix: pts-wake.sh agent poll uses startswith('pts-build-vm') — GCE registers with FQDN (pts-build-vm.us-central1-a.c.ci-runners-de.internal), exact match never fires (#140)
 
 - fix: pts-build-cleanup.yaml — remove stop-vm step (pts-build-vm self-stops after compile); update labels to platform:linux, tier:ondemand; delete pts-cleanup.sh (#140)

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -37,10 +37,23 @@ gsutil -m -q rsync -r "${BUILD_CACHE_BUCKET}/go-mod/" "${GOMODCACHE}/" 2>/dev/nu
     echo "    go-mod: $(du -sh "${GOMODCACHE}" | cut -f1)" || echo "    go-mod: cold"
 
 # ── Web UI ──
-echo ""; echo "==> Building web UI..."
-cd web && pnpm install --frozen-lockfile >/dev/null 2>&1 && pnpm build >/dev/null 2>&1
-echo "    $(ls dist/ | wc -l) files"
-cd ..
+# We never change the UI — restore the pre-built dist/ from GCS instead of
+# running pnpm on every compile. Only falls back to pnpm if GCS cache is empty.
+echo ""; echo "==> Restoring web UI dist/ from GCS cache..."
+mkdir -p web/dist
+gsutil -m -q rsync -r "${BUILD_CACHE_BUCKET}/woodpecker-web-dist/" web/dist/ 2>/dev/null
+DIST_COUNT=$(ls web/dist/ 2>/dev/null | wc -l)
+if [ "${DIST_COUNT}" -gt 10 ]; then
+    echo "    dist/: ${DIST_COUNT} files (from GCS cache)"
+else
+    echo "    GCS cache empty or stale — running pnpm build..."
+    cd web && pnpm install --no-frozen-lockfile >/dev/null 2>&1 && \
+        node_modules/.bin/vite build --base=/BASE_PATH >/dev/null 2>&1
+    echo "    dist/: $(ls dist/ | wc -l) files (freshly built)"
+    cd ..
+    gsutil -m -q rsync -r web/dist/ "${BUILD_CACHE_BUCKET}/woodpecker-web-dist/" 2>/dev/null && \
+        echo "    dist/ saved to GCS cache"
+fi
 
 # ── Compile ──
 mkdir -p bin


### PR DESCRIPTION
## Problem

pts-build.sh ran `pnpm install --frozen-lockfile && pnpm build` on every compile. The UI is never modified in our fork, so this wasted ~3 minutes and caused repeated failures due to pnpm version mismatches and lockfile conflicts. We agreed to cache it but never implemented the restore side.

## Fix

- Restore pre-built `dist/` from `gs://ci-runners-de-build-cache/woodpecker-web-dist/` before the Go compile
- Skip pnpm entirely when the GCS cache has >10 files (normal build)
- Fall back to pnpm build (using vite directly, `--no-frozen-lockfile`) only on cold cache, then save back to GCS
- Pre-built dist/ already populated in GCS from manual build 2026-05-07

🤖 Generated with [Claude Code](https://claude.com/claude-code)