### PR TITLE
fix: enforce Wants= in woodpecker-agent.service on every deploy (#112)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: woodpecker-deploy.sh enforces Wants= (not Requires=) in woodpecker-agent.service on every deploy — Requires= cascades server restarts to kill the local agent, interrupting in-flight pipelines (#112)
+
 - perf: pts-build.sh restores web UI dist/ from GCS cache instead of running pnpm on every compile — UI never changes so pnpm was wasted time; fallback to pnpm build only on cold cache, saves result back to GCS
 
 - fix: pts-wake.sh agent poll uses startswith('pts-build-vm') — GCE registers with FQDN (pts-build-vm.us-central1-a.c.ci-runners-de.internal), exact match never fires (#140)

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -177,6 +177,17 @@ find "${RELEASES_DIR}" -maxdepth 1 -mindepth 1 -type d | sort -r | \
     [ "${dir}" != "${current}" ] && rm -rf "${dir}" && echo "    Pruned: ${dir}"
 done
 
+# ── Enforce Wants= (not Requires=) in woodpecker-agent.service ──
+# Requires= cascades server restarts to the agent, killing in-flight pipelines.
+# Wants= starts the agent after the server but never stops it on server restart (#112).
+AGENT_UNIT="/etc/systemd/system/woodpecker-agent.service"
+if [ -f "${AGENT_UNIT}" ] && grep -q "^Requires=woodpecker-server" "${AGENT_UNIT}" 2>/dev/null; then
+    echo "    Fixing woodpecker-agent.service: Requires= → Wants="
+    sed -i 's/^Requires=woodpecker-server/Wants=woodpecker-server/' "${AGENT_UNIT}"
+    systemctl daemon-reload
+    echo "    woodpecker-agent.service fixed (daemon-reloaded)"
+fi
+
 # ── Enforce agent.env labels ──
 # The d3ci42-local agent must advertise ONLY backend=local — never platform=linux.
 # platform=linux causes it to compete with GCP VMs for regular CI tasks, running


### PR DESCRIPTION
## Summary

`woodpecker-deploy.sh` now enforces `Wants=woodpecker-server.service` (not `Requires=`) in `woodpecker-agent.service` on every deploy. Idempotent.

## Why

`Requires=` cascades server restarts to the local agent, killing in-flight pipelines. This was the root cause of pts-build compile steps being killed every time the server was restarted. `Wants=` keeps the agent alive through server restarts and lets it reconnect.

Already SSH-applied to d3ci42 on 2026-05-06. This codifies it so it survives future deploys.

Closes #112

## Test plan
- [ ] CI passes
- [ ] After merge + deploy: confirm `grep Wants /etc/systemd/system/woodpecker-agent.service` on d3ci42

🤖 Generated with [Claude Code](https://claude.com/claude-code)