### PR TITLE
feat: ephemeral pts-build-vm — always create from latest ci-agent image (#1669)

### DIFF
--- a/.woodpecker/pts-build-cleanup.yaml
+++ b/.woodpecker/pts-build-cleanup.yaml
@@ -10,6 +10,14 @@ labels:
 depends_on: [pts-build-compile]
 
 steps:
+  - name: delete-vm
+    image: bash
+    environment:
+      WOODPECKER_API_TOKEN:
+        from_secret: woodpecker_api_token
+    commands:
+      - scripts/woodpecker/pts-cleanup.sh
+
   - name: notify
     image: bash
     environment:
@@ -19,3 +27,4 @@ steps:
       - scripts/woodpecker/pts-notify.sh
     when:
       - status: [success, failure]
+    depends_on: [delete-vm]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: pts-build-vm is now ephemeral — pts-wake.sh creates fresh from ci-agent family image on every build; pts-cleanup.sh deletes the VM after compile. Eliminates image staleness (infra#1656), stale agent.conf, and manual taint/recreate cycle. (#1669)
+
 - perf: pts-build.sh restores web UI dist/ from GCS cache instead of running pnpm on every compile — UI never changes so pnpm was wasted time; fallback to pnpm build only on cold cache, saves result back to GCS
 
 - fix: pts-wake.sh agent poll uses startswith('pts-build-vm') — GCE registers with FQDN (pts-build-vm.us-central1-a.c.ci-runners-de.internal), exact match never fires (#140)

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -70,13 +70,8 @@ CGO_ENABLED=0 nice -n 10 go build \
     -ldflags "-s -w -X go.woodpecker-ci.org/woodpecker/v3/version.Version=${VERSION}" \
     -o bin/woodpecker-agent ./cmd/agent
 echo "    $(du -h bin/woodpecker-agent | cut -f1)"
-
-# Leave agent binary in place for the next pts-wake run — avoids the GitHub
-# Release download on every cold-start. The wake step finds this exact version
-# and uses it as the pts-build CI agent, ensuring agent/server version parity.
-cp bin/woodpecker-agent "/opt/woodpecker/woodpecker-agent-${VERSION}"
-chmod +x "/opt/woodpecker/woodpecker-agent-${VERSION}"
-echo "    agent binary cached: /opt/woodpecker/woodpecker-agent-${VERSION}"
+# Ephemeral VM (#1669): no local agent binary caching — VM is deleted after compile.
+# Agent binary is published via GitHub Release (Phase 3b) for Packer image baking.
 
 echo ""; echo "==> Saving GCS build cache..."
 gsutil -m -q rsync -r "${GOCACHE}/" "${BUILD_CACHE_BUCKET}/go-build/" 2>/dev/null && \

--- a/scripts/woodpecker/pts-cleanup.sh
+++ b/scripts/woodpecker/pts-cleanup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# pts-cleanup.sh — delete pts-build-vm after compile completes.
+# Ephemeral pattern (#1669): VM is deleted so next build always creates fresh
+# from latest ci-agent family image. Build cache persists in GCS.
+set -euo pipefail
+
+PTS_BUILD_PROJECT="ci-runners-de"
+PTS_BUILD_ZONE="us-central1-a"
+PTS_BUILD_VM="pts-build-vm"
+
+MY_PIPELINE="${CI_PIPELINE_NUMBER:-0}"
+
+# Mutex guard: skip delete if a newer pipeline has already claimed the VM.
+OWNER=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
+    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
+    --format="value(metadata.items[pts-build-pipeline])" 2>/dev/null || echo "")
+echo "==> Mutex check: my pipeline=#${MY_PIPELINE} owner=#${OWNER:-unknown}"
+
+if [ -n "${OWNER}" ] && [ "${OWNER}" -gt "${MY_PIPELINE}" ] 2>/dev/null; then
+    echo "    VM owned by newer pipeline #${OWNER} — skipping delete (superseded)"
+    exit 0
+fi
+
+echo "==> Deleting ${PTS_BUILD_VM} (ephemeral — fresh image on next build)..."
+gcloud compute instances delete "${PTS_BUILD_VM}" \
+    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet 2>/dev/null && \
+    echo "    deleted" || echo "    ⚠️  delete failed or VM already gone (non-fatal)"

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -1,61 +1,73 @@
 #!/usr/bin/env bash
-# pts-wake.sh — start pts-build-vm and wait for the Woodpecker agent to register.
-# The agent (woodpecker-agent.service) auto-starts via systemd on VM boot.
-# No SSH required — just start the VM and poll the Woodpecker API.
-# Runs on any GCP agent (platform:linux, tier:ondemand) — not backend:local (#140).
+# pts-wake.sh — provision pts-build-vm for woodpecker compilation (#1669).
+# Ephemeral pattern: always creates fresh from ci-agent family image so every
+# build gets the latest agent binary and toolchain. No image staleness, no
+# stale agent.conf, no manual taint/recreate cycle.
+#
+# States:
+#   NOT_FOUND / TERMINATED → create fresh
+#   RUNNING + active owner  → abort (concurrent build in progress)
+#   RUNNING + stale owner   → delete + recreate
+#
+# Build cache lives in GCS — no persistent disk needed.
 set -euo pipefail
 
 PTS_BUILD_PROJECT="ci-runners-de"
 PTS_BUILD_ZONE="us-central1-a"
 PTS_BUILD_VM="pts-build-vm"
-TTL_MINUTES=45  # boot (~3min) + cache restore (~10min) + compile (~20min) + slack
-
-WP_SERVER="d3ci42.peregrinetechsys.net"  # used only for reference
+WP_API="https://d3ci42.peregrinetechsys.net"
 
 # ── Concurrent-run guard ──
-# If pts-build-vm is already RUNNING and owned by an ACTIVE pipeline, abort.
-CURRENT_STATUS=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
+STATUS=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
     --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
-    --format="value(status)" 2>/dev/null || echo "UNKNOWN")
-if [ "${CURRENT_STATUS}" = "RUNNING" ]; then
+    --format="value(status)" 2>/dev/null || echo "NOT_FOUND")
+
+if [ "${STATUS}" = "RUNNING" ]; then
     OWNER_PIPELINE=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
         --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
-        --format="value(labels.pts-build-pipeline)" 2>/dev/null || echo "")
+        --format="value(metadata.items[pts-build-pipeline])" 2>/dev/null || echo "")
     if [ -n "${OWNER_PIPELINE}" ] && [ "${OWNER_PIPELINE}" != "0" ]; then
         OWNER_STATUS=$(curl -s --max-time 5 \
             -H "Authorization: Bearer ${WOODPECKER_API_TOKEN}" \
-            "http://localhost:8000/api/repos/13/pipelines/${OWNER_PIPELINE}" \
+            "${WP_API}/api/repos/13/pipelines/${OWNER_PIPELINE}" \
             2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" \
             2>/dev/null || echo "unknown")
         echo "==> ${PTS_BUILD_VM} RUNNING — owner=#${OWNER_PIPELINE} status=${OWNER_STATUS}"
         if [ "${OWNER_STATUS}" = "running" ] || [ "${OWNER_STATUS}" = "pending" ]; then
-            echo "    Active pipeline #${OWNER_PIPELINE} is compiling — skipping (#120)."
+            echo "    Active pipeline #${OWNER_PIPELINE} is compiling — aborting (#120)."
             exit 0
-        else
-            echo "    Stale label from #${OWNER_PIPELINE} (${OWNER_STATUS}) — taking ownership."
         fi
-    else
-        echo "==> ${PTS_BUILD_VM} RUNNING with no owner label — taking ownership."
     fi
+    echo "==> Stale or unowned VM — deleting before recreate..."
+    gcloud compute instances delete "${PTS_BUILD_VM}" \
+        --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet 2>/dev/null || true
 fi
 
-echo "==> Starting ${PTS_BUILD_VM} for pts-build v3.13.0-pts.${CI_PIPELINE_NUMBER:-0}..."
-gcloud compute instances start "${PTS_BUILD_VM}" \
-    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet
+# ── Create fresh from latest ci-agent family image ──
+echo "==> Creating ${PTS_BUILD_VM} from ci-agent family (pts.${CI_PIPELINE_NUMBER:-0})..."
+gcloud compute instances create "${PTS_BUILD_VM}" \
+    --project="${PTS_BUILD_PROJECT}" \
+    --zone="${PTS_BUILD_ZONE}" \
+    --machine-type=e2-standard-8 \
+    --image-family=ci-agent \
+    --image-project="${PTS_BUILD_PROJECT}" \
+    --boot-disk-size=50GB \
+    --boot-disk-type=pd-ssd \
+    --service-account="ci-agent@${PTS_BUILD_PROJECT}.iam.gserviceaccount.com" \
+    --scopes=cloud-platform \
+    --tags=pts-build,woodpecker-agent \
+    --metadata="agent-label=pts-build,ci-tier=ondemand,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}" \
+    --no-restart-on-failure \
+    --maintenance-policy=MIGRATE \
+    --quiet
+echo "    VM created from latest ci-agent image"
 
-# TTL labels — ttl-override-min tells ttl-reaper-dev-vm.sh to use this threshold
-# instead of its default 90min. ttl-expire-epoch is a secondary epoch-based marker.
-EXPIRE_EPOCH=$(( $(date +%s) + TTL_MINUTES * 60 ))
-gcloud compute instances add-labels "${PTS_BUILD_VM}" \
-    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
-    --labels="ttl-expire-epoch=${EXPIRE_EPOCH},ttl-override-min=${TTL_MINUTES},pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}"
-echo "    TTL label set: expire in ${TTL_MINUTES}min (epoch ${EXPIRE_EPOCH})"
-
-# The woodpecker-agent.service on pts-build-vm auto-starts on boot.
-# Poll the Woodpecker API until it registers (up to 3 min — accounts for boot time).
+# ── Poll until agent registers ──
+# woodpecker-agent-config.service runs on boot, writes agent.env, then
+# woodpecker-agent.service starts — allow ~3 min for this sequence.
 echo "==> Waiting for pts-build-vm agent to register with Woodpecker..."
 for i in $(seq 1 36); do
-    FOUND=$(curl -sf --max-time 5 "https://d3ci42.peregrinetechsys.net/api/agents" \
+    FOUND=$(curl -sf --max-time 5 "${WP_API}/api/agents" \
         -H "Authorization: Bearer ${WOODPECKER_API_TOKEN}" 2>/dev/null | \
         python3 -c "
 import sys,json,time


### PR DESCRIPTION
## Summary

Makes pts-build-vm ephemeral: pts-wake.sh creates it fresh from the `ci-agent` image family on every build; pts-cleanup.sh deletes it when done.

## Why

The static VM approach has caused repeated friction:
- infra#1656: image staleness (pnpm missing because VM was on a 2-day-old image)
- infra#1657: manual recompile + Packer bake needed to get pts.184 agent in
- Every ci-agent image release requires `terraform taint + apply` to update pts-build-vm
- Stale `agent.conf` after server restarts causes reconnect loops

## What changes

**pts-wake.sh**: replaces `gcloud instances start` with delete-then-create:
- `NOT_FOUND / TERMINATED` → `gcloud instances create --image-family=ci-agent`
- `RUNNING + active owner` → abort (concurrent build)
- `RUNNING + stale owner` → delete + recreate

**pts-build-cleanup.yaml**: adds `delete-vm` step back (runs `pts-cleanup.sh`)

**pts-cleanup.sh**: `gcloud instances delete` with mutex guard

**pts-build.sh**: removes local agent binary caching (VM is deleted; binary published via GitHub Release)

## VM spec (from infra#1669)
```
machine-type: e2-standard-8
image-family: ci-agent (always latest)
disk: 50GB pd-ssd (auto-deleted with VM)
SA: ci-agent@ci-runners-de.iam.gserviceaccount.com
tags: pts-build, woodpecker-agent
metadata: agent-label=pts-build, ci-tier=ondemand
```

Closes woodpecker#140 (fully), relates to infra#1656, infra#1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)