### PR TITLE
fix: pts-wake.sh --no-address to avoid IN_USE_ADDRESSES quota

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh adds --no-address to gcloud instances create — avoids IN_USE_ADDRESSES quota in us-central1 (limit=8, exhausted by fleet); Cloud NAT handles egress to d3ci42 without external IP
+
 - feat: pts-build-vm is now ephemeral — pts-wake.sh creates fresh from ci-agent family image on every build; pts-cleanup.sh deletes the VM after compile. Eliminates image staleness (infra#1656), stale agent.conf, and manual taint/recreate cycle. (#1669)
 
 - perf: pts-build.sh restores web UI dist/ from GCS cache instead of running pnpm on every compile — UI never changes so pnpm was wasted time; fallback to pnpm build only on cold cache, saves result back to GCS

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -57,6 +57,7 @@ gcloud compute instances create "${PTS_BUILD_VM}" \
     --scopes=cloud-platform \
     --tags=pts-build,woodpecker-agent \
     --metadata="agent-label=pts-build,ci-tier=ondemand,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}" \
+    --no-address \
     --no-restart-on-failure \
     --maintenance-policy=MIGRATE \
     --quiet


### PR DESCRIPTION
## Problem

Pipeline #281 failed: `Quota 'IN_USE_ADDRESSES' exceeded. Limit: 8.0 in region us-central1` — fleet agents consume all 8 external IP slots.

## Fix

Add `--no-address` to `gcloud instances create`. pts-build-vm only needs outbound connectivity to d3ci42 via WebSocket (HTTPS/443). Cloud NAT handles egress — no external IP required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)