### PR TITLE
feat: pts-wake.sh zone fallback for capacity failures (#150)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: pts-wake.sh zone fallback — tries all 11 agent zones in sequence on capacity failure; zone stored in VM metadata (pts-build-zone) so pts-cleanup.sh deletes in the correct zone (#150)
+
 - fix: pts-wake.sh adds --no-address to gcloud instances create — avoids IN_USE_ADDRESSES quota in us-central1 (limit=8, exhausted by fleet); Cloud NAT handles egress to d3ci42 without external IP
 
 - feat: pts-build-vm is now ephemeral — pts-wake.sh creates fresh from ci-agent family image on every build; pts-cleanup.sh deletes the VM after compile. Eliminates image staleness (infra#1656), stale agent.conf, and manual taint/recreate cycle. (#1669)

--- a/scripts/woodpecker/pts-cleanup.sh
+++ b/scripts/woodpecker/pts-cleanup.sh
@@ -2,26 +2,35 @@
 # pts-cleanup.sh — delete pts-build-vm after compile completes.
 # Ephemeral pattern (#1669): VM is deleted so next build always creates fresh
 # from latest ci-agent family image. Build cache persists in GCS.
+# Zone is read from VM metadata (pts-build-zone) since zone fallback (#150)
+# may have created the VM in any of the 11 agent zones.
 set -euo pipefail
 
 PTS_BUILD_PROJECT="ci-runners-de"
-PTS_BUILD_ZONE="us-central1-a"
 PTS_BUILD_VM="pts-build-vm"
-
 MY_PIPELINE="${CI_PIPELINE_NUMBER:-0}"
 
-# Mutex guard: skip delete if a newer pipeline has already claimed the VM.
-OWNER=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
-    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
-    --format="value(metadata.items[pts-build-pipeline])" 2>/dev/null || echo "")
-echo "==> Mutex check: my pipeline=#${MY_PIPELINE} owner=#${OWNER:-unknown}"
+# Find VM and its zone regardless of which zone it landed in
+DESCRIBE=$(gcloud compute instances list \
+    --project="${PTS_BUILD_PROJECT}" \
+    --filter="name=${PTS_BUILD_VM}" \
+    --format="value(zone,metadata.items[pts-build-pipeline])" 2>/dev/null | head -1)
+PTS_BUILD_ZONE=$(echo "${DESCRIBE}" | awk '{print $1}' | awk -F/ '{print $NF}')
+OWNER=$(echo "${DESCRIBE}" | awk '{print $2}')
+
+if [ -z "${PTS_BUILD_ZONE}" ]; then
+    echo "==> ${PTS_BUILD_VM} not found — already deleted or never created"
+    exit 0
+fi
+
+echo "==> Mutex check: my pipeline=#${MY_PIPELINE} owner=#${OWNER:-unknown} zone=${PTS_BUILD_ZONE}"
 
 if [ -n "${OWNER}" ] && [ "${OWNER}" -gt "${MY_PIPELINE}" ] 2>/dev/null; then
     echo "    VM owned by newer pipeline #${OWNER} — skipping delete (superseded)"
     exit 0
 fi
 
-echo "==> Deleting ${PTS_BUILD_VM} (ephemeral — fresh image on next build)..."
+echo "==> Deleting ${PTS_BUILD_VM} in ${PTS_BUILD_ZONE} (ephemeral — fresh image on next build)..."
 gcloud compute instances delete "${PTS_BUILD_VM}" \
     --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet 2>/dev/null && \
     echo "    deleted" || echo "    ⚠️  delete failed or VM already gone (non-fatal)"

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -4,8 +4,12 @@
 # build gets the latest agent binary and toolchain. No image staleness, no
 # stale agent.conf, no manual taint/recreate cycle.
 #
+# Zone fallback (#150): tries each of the 11 agent zones in sequence until one
+# has e2-standard-8 capacity. Zone used is stored in VM metadata so
+# pts-cleanup.sh can delete the VM in the correct zone.
+#
 # States:
-#   NOT_FOUND / TERMINATED → create fresh
+#   NOT_FOUND / TERMINATED → create fresh (zone fallback)
 #   RUNNING + active owner  → abort (concurrent build in progress)
 #   RUNNING + stale owner   → delete + recreate
 #
@@ -13,18 +17,25 @@
 set -euo pipefail
 
 PTS_BUILD_PROJECT="ci-runners-de"
-PTS_BUILD_ZONE="us-central1-a"
 PTS_BUILD_VM="pts-build-vm"
 WP_API="https://d3ci42.peregrinetechsys.net"
 
-# ── Concurrent-run guard ──
-STATUS=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
-    --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
-    --format="value(status)" 2>/dev/null || echo "NOT_FOUND")
+# Same zone list used by ci-image-builder bootstrap.sh (peregrine-infrastructure PR #1665)
+ZONE_LIST="us-central1-a us-central1-b us-east1-b us-east1-c us-east1-d us-west1-a us-west1-b us-west1-c us-east4-a us-east4-b us-south1-b"
 
-if [ "${STATUS}" = "RUNNING" ]; then
+# ── Concurrent-run guard ──
+# Describe without --zone so we find the VM regardless of which zone it's in.
+DESCRIBE=$(gcloud compute instances list \
+    --project="${PTS_BUILD_PROJECT}" \
+    --filter="name=${PTS_BUILD_VM}" \
+    --format="value(status,zone)" 2>/dev/null | head -1)
+STATUS=$(echo "${DESCRIBE}" | awk '{print $1}')
+CURRENT_ZONE=$(echo "${DESCRIBE}" | awk '{print $2}' | awk -F/ '{print $NF}')
+STATUS="${STATUS:-NOT_FOUND}"
+
+if [ "${STATUS}" = "RUNNING" ] && [ -n "${CURRENT_ZONE}" ]; then
     OWNER_PIPELINE=$(gcloud compute instances describe "${PTS_BUILD_VM}" \
-        --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" \
+        --zone="${CURRENT_ZONE}" --project="${PTS_BUILD_PROJECT}" \
         --format="value(metadata.items[pts-build-pipeline])" 2>/dev/null || echo "")
     if [ -n "${OWNER_PIPELINE}" ] && [ "${OWNER_PIPELINE}" != "0" ]; then
         OWNER_STATUS=$(curl -s --max-time 5 \
@@ -32,36 +43,49 @@ if [ "${STATUS}" = "RUNNING" ]; then
             "${WP_API}/api/repos/13/pipelines/${OWNER_PIPELINE}" \
             2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('status','unknown'))" \
             2>/dev/null || echo "unknown")
-        echo "==> ${PTS_BUILD_VM} RUNNING — owner=#${OWNER_PIPELINE} status=${OWNER_STATUS}"
+        echo "==> ${PTS_BUILD_VM} RUNNING in ${CURRENT_ZONE} — owner=#${OWNER_PIPELINE} status=${OWNER_STATUS}"
         if [ "${OWNER_STATUS}" = "running" ] || [ "${OWNER_STATUS}" = "pending" ]; then
             echo "    Active pipeline #${OWNER_PIPELINE} is compiling — aborting (#120)."
             exit 0
         fi
     fi
-    echo "==> Stale or unowned VM — deleting before recreate..."
+    echo "==> Stale or unowned VM in ${CURRENT_ZONE} — deleting before recreate..."
     gcloud compute instances delete "${PTS_BUILD_VM}" \
-        --zone="${PTS_BUILD_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet 2>/dev/null || true
+        --zone="${CURRENT_ZONE}" --project="${PTS_BUILD_PROJECT}" --quiet 2>/dev/null || true
 fi
 
-# ── Create fresh from latest ci-agent family image ──
+# ── Create fresh from latest ci-agent family image — zone fallback (#150) ──
 echo "==> Creating ${PTS_BUILD_VM} from ci-agent family (pts.${CI_PIPELINE_NUMBER:-0})..."
-gcloud compute instances create "${PTS_BUILD_VM}" \
-    --project="${PTS_BUILD_PROJECT}" \
-    --zone="${PTS_BUILD_ZONE}" \
-    --machine-type=e2-standard-8 \
-    --image-family=ci-agent \
-    --image-project="${PTS_BUILD_PROJECT}" \
-    --boot-disk-size=50GB \
-    --boot-disk-type=pd-ssd \
-    --service-account="ci-agent@${PTS_BUILD_PROJECT}.iam.gserviceaccount.com" \
-    --scopes=cloud-platform \
-    --tags=pts-build,woodpecker-agent \
-    --metadata="agent-label=pts-build,ci-tier=ondemand,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0}" \
-    --no-address \
-    --no-restart-on-failure \
-    --maintenance-policy=MIGRATE \
-    --quiet
-echo "    VM created from latest ci-agent image"
+CREATED_ZONE=""
+for ZONE in ${ZONE_LIST}; do
+    echo "    Trying zone ${ZONE}..."
+    if gcloud compute instances create "${PTS_BUILD_VM}" \
+            --project="${PTS_BUILD_PROJECT}" \
+            --zone="${ZONE}" \
+            --machine-type=e2-standard-8 \
+            --image-family=ci-agent \
+            --image-project="${PTS_BUILD_PROJECT}" \
+            --boot-disk-size=50GB \
+            --boot-disk-type=pd-ssd \
+            --service-account="ci-agent@${PTS_BUILD_PROJECT}.iam.gserviceaccount.com" \
+            --scopes=cloud-platform \
+            --tags=pts-build,woodpecker-agent \
+            --metadata="agent-label=pts-build,ci-tier=ondemand,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0},pts-build-zone=${ZONE}" \
+            --no-address \
+            --no-restart-on-failure \
+            --maintenance-policy=MIGRATE \
+            --quiet 2>&1; then
+        CREATED_ZONE="${ZONE}"
+        echo "    VM created in ${CREATED_ZONE} from latest ci-agent image"
+        break
+    fi
+    echo "    WARN: ${ZONE} capacity unavailable — trying next zone"
+done
+
+if [ -z "${CREATED_ZONE}" ]; then
+    echo "ERROR: could not create ${PTS_BUILD_VM} in any zone — all zones at capacity"
+    exit 1
+fi
 
 # ── Poll until agent registers ──
 # woodpecker-agent-config.service runs on boot, writes agent.env, then


### PR DESCRIPTION
## Problem

pts-wake.sh hardcoded `us-central1-a` with no fallback. If that zone is at e2-standard-8 capacity, the ephemeral create fails and the build is blocked.

## Fix

Try all 11 agent zones in sequence (same pattern as ci-image-builder bootstrap.sh in peregrine-infrastructure PR #1665). Zone used is stored in `pts-build-zone` VM metadata so pts-cleanup.sh can delete in the correct zone.

**pts-wake.sh**: zone-cycling loop, concurrent guard uses `instances list` (zone-agnostic).
**pts-cleanup.sh**: reads zone from VM metadata, falls back gracefully if VM not found.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)