### PR TITLE
fix: remove --no-address — use free ephemeral IP for outbound connectivity

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh removes --no-address — Cloud NAT not configured in ci-runners-de so --no-address leaves VM with no internet, blocking agent-config from reaching GCP SM; zone fallback already handles regional IP quota (#149 revert)
+
 - chore: pts-build trigger changed from push-to-main to manual-only — prevents server restart cascade from killing all in-flight pipelines on every code merge (#152)
 
 - feat: pts-wake.sh zone fallback — tries all 11 agent zones in sequence on capacity failure; zone stored in VM metadata (pts-build-zone) so pts-cleanup.sh deletes in the correct zone (#150)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -71,7 +71,6 @@ for ZONE in ${ZONE_LIST}; do
             --scopes=cloud-platform \
             --tags=pts-build,woodpecker-agent \
             --metadata="agent-label=pts-build,ci-tier=ondemand,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0},pts-build-zone=${ZONE}" \
-            --no-address \
             --no-restart-on-failure \
             --maintenance-policy=MIGRATE \
             --quiet 2>&1; then


### PR DESCRIPTION
## Problem

`--no-address` left pts-build-vm with no internet access, blocking `woodpecker-agent-config.sh` from reaching GCP Secret Manager and the Woodpecker server.

## Fix

Remove `--no-address`. The default ephemeral external IP is free while the VM runs and released on delete. Zone fallback already handles the regional `IN_USE_ADDRESSES` quota by trying us-east1/us-west1 when us-central1 is full.

Reverts woodpecker#149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)