### PR TITLE
fix: add event:manual to pts-build-compile and pts-build-cleanup

### DIFF
--- a/.woodpecker/pts-build-cleanup.yaml
+++ b/.woodpecker/pts-build-cleanup.yaml
@@ -1,5 +1,5 @@
 when:
-  - event: push
+  - event: [push, manual]
     branch: main
     status: [success, failure]
 

--- a/.woodpecker/pts-build-compile.yaml
+++ b/.woodpecker/pts-build-compile.yaml
@@ -1,5 +1,5 @@
 when:
-  - event: push
+  - event: [push, manual]
     branch: main
 
 labels:

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-build-compile.yaml and pts-build-cleanup.yaml add event:manual so compile and cleanup run on manual pts-build triggers (#153)
+
 - fix: pts-wake.sh removes --no-address — Cloud NAT not configured in ci-runners-de so --no-address leaves VM with no internet, blocking agent-config from reaching GCP SM; zone fallback already handles regional IP quota (#149 revert)
 
 - chore: pts-build trigger changed from push-to-main to manual-only — prevents server restart cascade from killing all in-flight pipelines on every code merge (#152)


### PR DESCRIPTION
After switching pts-build to manual-only (#153), compile and cleanup workflows still required event:push — manual triggers ran wake but skipped everything else. Closes the gap.