### PR TITLE
feat: pts-build.sh creates infra tracking issue on successful build (SOC 2)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: pts-build.sh creates infra tracking issue on every successful build (Phase 3d) — SOC 2 CC7.2 traceability; the auto-PR from ci-image-builder must be linked to this issue before merge
+
 - fix: pts-build-compile.yaml and pts-build-cleanup.yaml add event:manual so compile and cleanup run on manual pts-build triggers (#153)
 
 - fix: pts-wake.sh removes --no-address — Cloud NAT not configured in ci-runners-de so --no-address leaves VM with no internet, blocking agent-config from reaching GCP SM; zone fallback already handles regional IP quota (#149 revert)

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -167,5 +167,23 @@ else
 fi
 rm -f "${JOB_FILE}"
 
+# ── Create infra tracking issue (SOC 2 CC7.2 traceability) ──
+# The ci-image-builder auto-PR (chore/agent-image-bump) must be linked to
+# an issue for our standard PR→issue audit trail.
+echo ""; echo "==> Phase 3d: create infra tracking issue"
+if [ -n "${GH_TOKEN:-}" ]; then
+    INFRA_REPO="Peregrine-Technology-Systems/peregrine-infrastructure"
+    ISSUE_BODY="## Build record\n\n- **Version:** ${VERSION}\n- **Pipeline:** #${CI_PIPELINE_NUMBER:-?}\n- **Commit:** \`${COMMIT_SHA:0:8}\` on woodpecker fork\n- **Binary SHA256:** \`${SHA256:0:16}...\`\n- **GitHub Release:** https://github.com/Peregrine-Technology-Systems/woodpecker/releases/tag/${VERSION}\n\n## Action\n\nReview and merge the auto-generated \`chore/agent-image-bump\` PR to pin the new ci-agent image to this agent binary. The PR is opened automatically by ci-image-builder.\n\nLink that PR to this issue before merging (SOC 2 CC7.2 traceability)."
+    ISSUE_RESP=$(curl -sS -X POST \
+        -H "Authorization: Bearer ${GH_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "https://api.github.com/repos/${INFRA_REPO}/issues" \
+        -d "{\"title\":\"chore: pin ci-agent image built from ${VERSION}\",\"body\":\"${ISSUE_BODY}\"}")
+    ISSUE_URL=$(echo "${ISSUE_RESP}" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(d.get("html_url",""))' 2>/dev/null || echo "")
+    [ -n "${ISSUE_URL}" ] && echo "    Tracking issue: ${ISSUE_URL}" || echo "    ⚠️  Could not create tracking issue (non-blocking)"
+else
+    echo "    Skipping: GH_TOKEN not set"
+fi
+
 echo ""; echo "==> pts-build complete: ${VERSION}"
 echo "    Deployment will complete within 2 minutes via woodpecker-deploy.sh on d3ci42."


### PR DESCRIPTION
## Why

SOC 2 CC7.2: every PR must be linked to a trackable issue. The ci-image-builder auto-creates the `chore/agent-image-bump` PR, but there was no corresponding issue — the PR had no audit trail.

## What

Phase 3d added to pts-build.sh: after triggering ci-image-builder, create an issue in `peregrine-infrastructure` recording the build version, pipeline number, commit, and binary SHA256. The issue description instructs the reviewer to link the auto-PR to this issue before merging.

## Result

Each pts-build produces:
1. GitHub Release with binaries (already existed)
2. Infra tracking issue (new — this PR)
3. Auto-PR from ci-image-builder linked to that issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)