### PR TITLE
fix: remove ci-tier=ondemand from pts-build-vm metadata (#159)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-wake.sh removes ci-tier=ondemand from VM metadata — pts-build-vm was registering as a general-purpose ondemand agent and picking up regular CI tasks when cleanup was delayed; compile step routes via agent:pts-build so the tier label is redundant (#159)
+
 - feat: pts-build.sh creates infra tracking issue on every successful build (Phase 3d) — SOC 2 CC7.2 traceability; the auto-PR from ci-image-builder must be linked to this issue before merge
 
 - fix: pts-build-compile.yaml and pts-build-cleanup.yaml add event:manual so compile and cleanup run on manual pts-build triggers (#153)

--- a/scripts/woodpecker/pts-wake.sh
+++ b/scripts/woodpecker/pts-wake.sh
@@ -70,7 +70,7 @@ for ZONE in ${ZONE_LIST}; do
             --service-account="ci-agent@${PTS_BUILD_PROJECT}.iam.gserviceaccount.com" \
             --scopes=cloud-platform \
             --tags=pts-build,woodpecker-agent \
-            --metadata="agent-label=pts-build,ci-tier=ondemand,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0},pts-build-zone=${ZONE}" \
+            --metadata="agent-label=pts-build,pts-build-pipeline=${CI_PIPELINE_NUMBER:-0},pts-build-zone=${ZONE}" \
             --no-restart-on-failure \
             --maintenance-policy=MIGRATE \
             --quiet 2>&1; then


### PR DESCRIPTION
## Summary

- Removes `ci-tier=ondemand` from `pts-wake.sh` VM metadata so pts-build-vm no longer registers as a general-purpose ondemand agent
- pts-build-compile routes via `agent: pts-build` exclusively — the tier label was redundant and caused task leakage when cleanup was delayed

## Root cause

After pipeline #300 completed, the cleanup workflow was skipped (#159 tracks the skip root cause). pts-build-vm stayed alive, registered as `tier: ondemand`, and picked up scaler integration-test pipeline #1828. The ondemand MIG held target=1 unnecessarily.

## Test plan

- [ ] Next pts-build run: pts-build-vm registers with only `agent: pts-build` — not visible in ondemand pool
- [ ] Cleanup skip no longer causes task leakage