### PR TITLE
fix: evict zombie tasks from terminal pipelines on queue restore (#154)

### DIFF
--- a/.woodpecker/pts-build.yaml
+++ b/.woodpecker/pts-build.yaml
@@ -1,5 +1,6 @@
 when:
   - event: manual
+    branch: main
 
 labels:
   platform: linux

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-build.yaml missing branch:main filter — any manual trigger on a non-main branch creates an orphaned pts-build-vm; compile never runs so cleanup skips too (#163)
+
 - fix: step_builder.go: IncludesStatusSuccess used for success RunsOn population — copy-paste bug used IncludesStatusFailure for both failure and success, causing workflows with when.status:[success] (without failure) to never be added to RunsOn and therefore never dispatch (#162)
 
 - fix: WithTaskStore evicts zombie tasks from terminal pipelines on startup — tasks whose pipeline is killed/success/error/failed were loaded into the in-memory queue and inflated pending metrics indefinitely; now detected via GetPipeline lookup and deleted from the store before queue restore (#154)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: WithTaskStore evicts zombie tasks from terminal pipelines on startup — tasks whose pipeline is killed/success/error/failed were loaded into the in-memory queue and inflated pending metrics indefinitely; now detected via GetPipeline lookup and deleted from the store before queue restore (#154)
+
 - fix: woodpecker-deploy.sh enforces Wants= (not Requires=) in woodpecker-agent.service on every deploy — Requires= cascades server restarts to kill the local agent, interrupting in-flight pipelines (#112)
 - fix: pts-wake.sh removes ci-tier=ondemand from VM metadata — pts-build-vm was registering as a general-purpose ondemand agent and picking up regular CI tasks when cleanup was delayed; compile step routes via agent:pts-build so the tier label is redundant (#159)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: step_builder.go: IncludesStatusSuccess used for success RunsOn population — copy-paste bug used IncludesStatusFailure for both failure and success, causing workflows with when.status:[success] (without failure) to never be added to RunsOn and therefore never dispatch (#162)
+
 - fix: WithTaskStore evicts zombie tasks from terminal pipelines on startup — tasks whose pipeline is killed/success/error/failed were loaded into the in-memory queue and inflated pending metrics indefinitely; now detected via GetPipeline lookup and deleted from the store before queue restore (#154)
 
 - fix: woodpecker-deploy.sh enforces Wants= (not Requires=) in woodpecker-agent.service on every deploy — Requires= cascades server restarts to kill the local agent, interrupting in-flight pipelines (#112)

--- a/server/pipeline/stepbuilder/step_builder.go
+++ b/server/pipeline/stepbuilder/step_builder.go
@@ -193,7 +193,7 @@ func (b *StepBuilder) genItemForWorkflow(workflow *model.Workflow, axis matrix.A
 	if !slices.Contains(item.RunsOn, "failure") && parsed.When.IncludesStatusFailure(workflowMetadata, true, environ) {
 		item.RunsOn = append(item.RunsOn, "failure")
 	}
-	if !slices.Contains(item.RunsOn, "success") && parsed.When.IncludesStatusFailure(workflowMetadata, true, environ) {
+	if !slices.Contains(item.RunsOn, "success") && parsed.When.IncludesStatusSuccess(workflowMetadata, true, environ) {
 		item.RunsOn = append(item.RunsOn, "success")
 	}
 

--- a/server/queue/persistent.go
+++ b/server/queue/persistent.go
@@ -29,12 +29,55 @@ import (
 
 // WithTaskStore returns a queue that is backed by the TaskStore. This
 // ensures the task Queue can be restored when the system starts.
+// Zombie tasks — tasks whose parent pipeline is in a terminal state — are
+// evicted from the store and not loaded into the in-memory queue (#154).
 func WithTaskStore(ctx context.Context, q Queue, s store.Store) Queue {
 	tasks, _ := s.TaskList()
-	if err := q.PushAtOnce(ctx, tasks); err != nil {
+
+	var valid []*model.Task
+	evicted := 0
+	for _, task := range tasks {
+		pl, err := s.GetPipeline(task.PipelineID)
+		if err != nil {
+			// Pipeline not found — orphaned task; evict it.
+			log.Warn().Msgf("queue restore: task %s has no pipeline %d — evicting", task.ID, task.PipelineID)
+			_ = s.TaskDelete(task.ID)
+			evicted++
+			continue
+		}
+		if isTerminalPipeline(pl.Status) {
+			if deleteErr := s.TaskDelete(task.ID); deleteErr != nil {
+				log.Error().Err(deleteErr).Msgf("queue restore: failed to delete zombie task %s", task.ID)
+			} else {
+				log.Info().Msgf("queue restore: evicted zombie task %s (pipeline %d status=%s)", task.ID, task.PipelineID, pl.Status)
+				evicted++
+			}
+			continue
+		}
+		valid = append(valid, task)
+	}
+	if evicted > 0 {
+		log.Info().Msgf("queue restore: evicted %d zombie tasks from terminal pipelines (#154)", evicted)
+	}
+
+	if err := q.PushAtOnce(ctx, valid); err != nil {
 		log.Error().Err(err).Msg("PushAtOnce failed")
 	}
 	return &persistentQueue{q, s}
+}
+
+// isTerminalPipeline returns true when a pipeline has reached a final state
+// and will never dispatch further tasks. Tasks from terminal pipelines are
+// zombies — they will never be picked up and should be evicted on startup.
+func isTerminalPipeline(status model.StatusValue) bool {
+	switch status {
+	case model.StatusSuccess, model.StatusFailure, model.StatusKilled,
+		model.StatusError, model.StatusDeclined, model.StatusSkipped,
+		model.StatusSuperseded, model.StatusCanceled:
+		return true
+	default:
+		return false
+	}
 }
 
 type persistentQueue struct {

--- a/server/queue/persistent_test.go
+++ b/server/queue/persistent_test.go
@@ -1,0 +1,77 @@
+// Copyright 2026 Woodpecker Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package queue
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"go.woodpecker-ci.org/woodpecker/v3/server/model"
+	storemocks "go.woodpecker-ci.org/woodpecker/v3/server/store/mocks"
+)
+
+func TestWithTaskStore_EvictsZombieTasks(t *testing.T) {
+	tasks := []*model.Task{
+		{ID: "alive-1", PipelineID: 1},
+		{ID: "alive-2", PipelineID: 2},
+		{ID: "zombie-killed", PipelineID: 10},
+		{ID: "zombie-success", PipelineID: 11},
+		{ID: "zombie-error", PipelineID: 12},
+		{ID: "zombie-no-pipeline", PipelineID: 99},
+	}
+
+	s := storemocks.NewMockStore(t)
+	s.On("TaskList").Return(tasks, nil)
+	s.On("GetPipeline", int64(1)).Return(&model.Pipeline{ID: 1, Status: model.StatusRunning}, nil)
+	s.On("GetPipeline", int64(2)).Return(&model.Pipeline{ID: 2, Status: model.StatusPending}, nil)
+	s.On("GetPipeline", int64(10)).Return(&model.Pipeline{ID: 10, Status: model.StatusKilled}, nil)
+	s.On("GetPipeline", int64(11)).Return(&model.Pipeline{ID: 11, Status: model.StatusSuccess}, nil)
+	s.On("GetPipeline", int64(12)).Return(&model.Pipeline{ID: 12, Status: model.StatusError}, nil)
+	s.On("GetPipeline", int64(99)).Return(nil, fmt.Errorf("not found"))
+	s.On("TaskDelete", mock.AnythingOfType("string")).Return(nil)
+
+	ctx := context.Background()
+	inner, _ := New(ctx, Config{Backend: TypeMemory})
+	WithTaskStore(ctx, inner, s)
+
+	// Verify zombie tasks were deleted
+	for _, zombie := range []string{"zombie-killed", "zombie-success", "zombie-error", "zombie-no-pipeline"} {
+		s.AssertCalled(t, "TaskDelete", zombie)
+	}
+	// Verify alive tasks were NOT deleted
+	s.AssertNotCalled(t, "TaskDelete", "alive-1")
+	s.AssertNotCalled(t, "TaskDelete", "alive-2")
+}
+
+func TestIsTerminalPipeline(t *testing.T) {
+	terminal := []model.StatusValue{
+		model.StatusSuccess, model.StatusFailure, model.StatusKilled,
+		model.StatusError, model.StatusDeclined, model.StatusSkipped,
+		model.StatusSuperseded, model.StatusCanceled,
+	}
+	active := []model.StatusValue{
+		model.StatusRunning, model.StatusPending, model.StatusCreated, model.StatusBlocked,
+	}
+	for _, s := range terminal {
+		assert.True(t, isTerminalPipeline(s), "expected terminal: %s", s)
+	}
+	for _, s := range active {
+		assert.False(t, isTerminalPipeline(s), "expected active: %s", s)
+	}
+}


### PR DESCRIPTION
## Summary

- `WithTaskStore` now filters out tasks whose parent pipeline is in a terminal state before loading into the in-memory queue
- Zombie tasks are deleted from the store; tasks with a missing pipeline are also evicted
- Previously, these inflated queue depth metrics indefinitely after server restarts, causing Grafana to show phantom pending work and the scaler to scale up unnecessarily

## Terminal states evicted

`killed`, `success`, `error`, `failure`, `declined`, `skipped`, `superseded`, `canceled`

## Test plan

- [ ] `TestWithTaskStore_EvictsZombieTasks` — 4 zombie tasks evicted (killed, success, error, no-pipeline), 2 alive tasks untouched
- [ ] `TestIsTerminalPipeline` — all 8 terminal statuses return true, all 4 active statuses return false