### PR TITLE
perf: drop go-mod GCS cache, use go mod download (#164)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- perf: drop go-mod GCS cache — replace with go mod download; module cache had grown to 3.5GB and blocked pts-build #314 for 15min on restore; go mod download fetches only what go.sum requires in ~30s (#164)
+
 - fix: pts-build.yaml missing branch:main filter — any manual trigger on a non-main branch creates an orphaned pts-build-vm; compile never runs so cleanup skips too (#163)
 
 - fix: step_builder.go: IncludesStatusSuccess used for success RunsOn population — copy-paste bug used IncludesStatusFailure for both failure and success, causing workflows with when.status:[success] (without failure) to never be added to RunsOn and therefore never dispatch (#162)

--- a/scripts/woodpecker/pts-build.sh
+++ b/scripts/woodpecker/pts-build.sh
@@ -30,11 +30,15 @@ else
 fi
 mkdir -p "${GOCACHE}" "${GOMODCACHE}"
 
-echo "==> Restoring GCS build cache..."
+echo "==> Restoring GCS build cache (go-build only)..."
 gsutil -m -q rsync -r "${BUILD_CACHE_BUCKET}/go-build/" "${GOCACHE}/" 2>/dev/null && \
     echo "    go-build: $(du -sh "${GOCACHE}" | cut -f1)" || echo "    go-build: cold"
-gsutil -m -q rsync -r "${BUILD_CACHE_BUCKET}/go-mod/" "${GOMODCACHE}/" 2>/dev/null && \
-    echo "    go-mod: $(du -sh "${GOMODCACHE}" | cut -f1)" || echo "    go-mod: cold"
+
+# go-mod: download only what go.sum requires — faster and never accumulates stale
+# modules. GCS go-mod/ is intentionally NOT restored (#164).
+echo "==> Downloading Go modules (go mod download)..."
+export GOMODCACHE
+go mod download 2>/dev/null && echo "    modules ready" || echo "    ⚠️  go mod download had warnings (non-fatal)"
 
 # ── Web UI ──
 # We never change the UI — restore the pre-built dist/ from GCS instead of
@@ -73,11 +77,10 @@ echo "    $(du -h bin/woodpecker-agent | cut -f1)"
 # Ephemeral VM (#1669): no local agent binary caching — VM is deleted after compile.
 # Agent binary is published via GitHub Release (Phase 3b) for Packer image baking.
 
-echo ""; echo "==> Saving GCS build cache..."
+echo ""; echo "==> Saving GCS build cache (go-build only)..."
 gsutil -m -q rsync -r "${GOCACHE}/" "${BUILD_CACHE_BUCKET}/go-build/" 2>/dev/null && \
     echo "    go-build saved" || echo "    ⚠️  go-build save failed (non-fatal)"
-gsutil -m -q rsync -r "${GOMODCACHE}/" "${BUILD_CACHE_BUCKET}/go-mod/" 2>/dev/null && \
-    echo "    go-mod saved" || echo "    ⚠️  go-mod save failed (non-fatal)"
+# go-mod not saved — go mod download is faster than GCS rsync for 3.5GB (#164)
 
 # ── Upload binary to GCS for deployment ──
 # woodpecker-deploy.sh on d3ci42 polls DEPLOY_BUCKET/pending and picks this up.


### PR DESCRIPTION
## Problem

pts-build #314 spent 15+ minutes blocked on `gsutil rsync` restoring a 3.5GB go-mod cache from GCS. The cache grows unboundedly as it accumulates modules from old dependency versions no longer in `go.sum`.

## Fix

- Drop go-mod GCS restore/save entirely
- Replace with `go mod download` — downloads only modules in `go.sum`, ~30s from the Go module proxy
- Keep go-build GCS cache (compiled object files — worth caching)

## Follow-up

Delete `gs://ci-runners-de-build-cache/go-mod/` after this merges.