### PR TITLE
fix: pts-build-cleanup on d3ci42-local — fixes killed pipeline status (#166)

### DIFF
--- a/.woodpecker/pts-build-cleanup.yaml
+++ b/.woodpecker/pts-build-cleanup.yaml
@@ -4,8 +4,7 @@ when:
     status: [success, failure]
 
 labels:
-  platform: linux
-  tier: ondemand
+  backend: local
 
 depends_on: [pts-build-compile]
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: pts-build-cleanup runs on d3ci42-local (backend:local) instead of tier:ondemand MIG — MIG agent not available immediately after compile completes, causing pipeline to time out and show killed; d3ci42-local is always connected and picks up cleanup instantly (#166)
+
 - perf: drop go-mod GCS cache — replace with go mod download; module cache had grown to 3.5GB and blocked pts-build #314 for 15min on restore; go mod download fetches only what go.sum requires in ~30s (#164)
 
 - fix: pts-build.yaml missing branch:main filter — any manual trigger on a non-main branch creates an orphaned pts-build-vm; compile never runs so cleanup skips too (#163)


### PR DESCRIPTION
Fixes the cosmetic `killed` status on pts-build pipelines.\n\n## Change\n\n`pts-build-cleanup.yaml`: `labels: platform:linux, tier:ondemand` → `labels: backend:local`\n\nRoutes cleanup to d3ci42-local which is always connected and picks up the task immediately after compile completes. Previously needed a MIG agent which wasn't available in time → pipeline timed out → showed killed.