### PR TITLE
fix: agent disconnect preserves workflow status when steps completed (#168)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: agent disconnect no longer marks workflow killed when all steps already completed — disconnect handler unconditionally set StatusKilled even when every step had exit_code=0; now computes workflow status from steps if none were in-flight (#168)
+
 - perf: drop go-mod GCS cache — replace with go mod download; module cache had grown to 3.5GB and blocked pts-build #314 for 15min on restore; go mod download fetches only what go.sum requires in ~30s (#164)
 
 - fix: pts-build.yaml missing branch:main filter — any manual trigger on a non-main branch creates an orphaned pts-build-vm; compile never runs so cleanup skips too (#163)

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -258,7 +258,10 @@ func (s *RPC) ReleaseAgentTasks(c context.Context, agentID int64) {
 
 		now := time.Now().Unix()
 
-		// Mark pending/running steps as killed
+		// Mark pending/running steps as killed. Track whether any steps
+		// were actually in-flight — if all steps already completed, the
+		// workflow should reflect their outcome, not be marked killed (#168).
+		anyKilled := false
 		for _, step := range workflow.Children {
 			if step.Running() || step.State == model.StatusPending {
 				step.State = model.StatusKilled
@@ -268,16 +271,22 @@ func (s *RPC) ReleaseAgentTasks(c context.Context, agentID int64) {
 					log.Error().Err(err).Int64("step_id", step.ID).
 						Msg("release: failed to kill step")
 				}
+				anyKilled = true
 			}
 		}
 
-		// Mark workflow as killed
-		workflow.State = model.StatusKilled
+		// If all steps had already completed before the disconnect, compute
+		// workflow status from them instead of marking killed (#168).
 		workflow.Finished = now
-		workflow.Error = "agent disconnected"
+		if anyKilled {
+			workflow.State = model.StatusKilled
+			workflow.Error = "agent disconnected"
+		} else {
+			workflow.State = pipeline.WorkflowStatus(workflow.Children)
+		}
 		if err := s.store.WorkflowUpdate(workflow); err != nil {
 			log.Error().Err(err).Int64("workflow_id", workflowID).
-				Msg("release: failed to kill workflow")
+				Msg("release: failed to update workflow on disconnect")
 		}
 
 		// Update parent pipeline status


### PR DESCRIPTION
## Problem

pts-build pipelines showed `partial` instead of `success`. The compile workflow (`pts-build-compile`) showed `killed` even though both steps had `state=success, exit_code=0`.

Root cause: the agent disconnect handler in `server/rpc/rpc.go` unconditionally sets `workflow.State = StatusKilled` regardless of whether any steps were actually in-flight.

## Fix

Track whether any steps were killed. If none were (all already completed before disconnect), compute workflow status from steps via `WorkflowStatus()` instead of marking killed.