### PR TITLE
fix: run ReconcileOrphaned on 2min background timer (#170)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: ReconcileOrphaned runs every 2min on a background timer — orphaned pipelines created post-startup are now auto-killed within 2 minutes instead of requiring server restart (#170)
+
 - fix: agent disconnect no longer marks workflow killed when all steps already completed — disconnect handler unconditionally set StatusKilled even when every step had exit_code=0; now computes workflow status from steps if none were in-flight (#168)
 - fix: pts-build-cleanup runs on d3ci42-local (backend:local) instead of tier:ondemand MIG — MIG agent not available immediately after compile completes, causing pipeline to time out and show killed; d3ci42-local is always connected and picks up cleanup instantly (#166)
 

--- a/cmd/server/setup.go
+++ b/cmd/server/setup.go
@@ -197,6 +197,22 @@ func setupEvilGlobals(ctx context.Context, c *cli.Command, s store.Store) (err e
 	// have no queue task and will never complete. Mark them as killed.
 	pipeline.ReconcileOrphaned(s)
 
+	// #170: Run ReconcileOrphaned on a 2-minute background timer so pipelines
+	// orphaned after startup (agent disconnect, VM preemption) are also caught.
+	// The function is idempotent and safe to call repeatedly.
+	go func() {
+		ticker := time.NewTicker(2 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				pipeline.ReconcileOrphaned(s)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
 	// WebSocket agent transport (#474) — shares business logic with gRPC
 	server.Config.Services.WSAgentRPC = woodpeckerGrpc.NewRPC(
 		server.Config.Services.Queue,


### PR DESCRIPTION
## Summary

- `ReconcileOrphaned` previously only ran once at server startup; pipelines orphaned post-startup (agent disconnect, VM preemption) stayed stuck in `running` state indefinitely, holding scaler MIG targets non-zero.
- Adds a background goroutine in `setupEvilGlobals` that ticks every 2 minutes and calls `pipeline.ReconcileOrphaned(store)`.
- Goroutine exits cleanly when `ctx` is cancelled (server shutdown).

## Changes

- `cmd/server/setup.go`: background goroutine after startup reconcile call
- `RELEASE_NOTES.md`: entry for #170

## Test plan

- [ ] Verify server starts and the goroutine doesn't block startup
- [ ] Start a pipeline, disconnect the agent mid-run, confirm the pipeline is marked killed within 2 minutes without a server restart
- [ ] Verify server shuts down cleanly (goroutine exits on ctx cancel)

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)