### PR TITLE
feat: batch WP fixes — metrics aliases, API 404, JWT rotation, pipeline status, stale-conf, queue logging (#173,#27,#95,#77,#162,#92,#111,#116)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: agent proactively reconnects at 75% of JWT token lifetime when idle — prevents expiry-caused WS rejection without requiring manual intervention (#116; proto-based extend refresh is a follow-up)
 - fix: pipeline status stays 'running' while any workflow is still executing — previously a canceled cleanup workflow could collapse a running compile to 'killed' (#111)
 - feat: woodpecker-deploy.sh auto-rotates JWT secret and API token on every deploy — eliminates manual token rotation after server restarts (#92)
 - fix: queue logs debug-level reason when task skipped in filterWaiting/ShouldRun — surfaces root cause for pts-build-cleanup skips on manual trigger (#162)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- feat: dual-emit ci_* aliases for Woodpecker server metrics — Grafana dashboards can migrate from woodpecker_* prefix without gaps (#173)
+
 - fix: ReconcileOrphaned runs every 2min on a background timer — orphaned pipelines created post-startup are now auto-killed within 2 minutes instead of requiring server restart (#170)
 
 - fix: agent disconnect no longer marks workflow killed when all steps already completed — disconnect handler unconditionally set StatusKilled even when every step had exit_code=0; now computes workflow status from steps if none were in-flight (#168)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: woodpecker-deploy.sh auto-rotates JWT secret and API token on every deploy — eliminates manual token rotation after server restarts (#92)
 - fix: queue logs debug-level reason when task skipped in filterWaiting/ShouldRun — surfaces root cause for pts-build-cleanup skips on manual trigger (#162)
 - fix: agent now detects Unauthenticated (JWT expired/rotated) at WS connect time and deletes stale agent.conf — previously looped forever on sql: no rows without self-healing (#77)
 - fix: YAML compiler logs parse errors at ERROR level with filename — non-ASCII/invalid UTF-8 in pipeline YAML previously failed silently, blocking all workflows in the repo (#95)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: agent now detects Unauthenticated (JWT expired/rotated) at WS connect time and deletes stale agent.conf — previously looped forever on sql: no rows without self-healing (#77)
 - fix: YAML compiler logs parse errors at ERROR level with filename — non-ASCII/invalid UTF-8 in pipeline YAML previously failed silently, blocking all workflows in the repo (#95)
 - fix: unknown /api/* paths now return 404 JSON instead of SPA HTML — prevents client tools from silently parsing HTML as API response (#27)
 - feat: dual-emit ci_* aliases for Woodpecker server metrics — Grafana dashboards can migrate from woodpecker_* prefix without gaps (#173)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: unknown /api/* paths now return 404 JSON instead of SPA HTML — prevents client tools from silently parsing HTML as API response (#27)
 - feat: dual-emit ci_* aliases for Woodpecker server metrics — Grafana dashboards can migrate from woodpecker_* prefix without gaps (#173)
 
 - fix: ReconcileOrphaned runs every 2min on a background timer — orphaned pipelines created post-startup are now auto-killed within 2 minutes instead of requiring server restart (#170)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: queue logs debug-level reason when task skipped in filterWaiting/ShouldRun — surfaces root cause for pts-build-cleanup skips on manual trigger (#162)
 - fix: agent now detects Unauthenticated (JWT expired/rotated) at WS connect time and deletes stale agent.conf — previously looped forever on sql: no rows without self-healing (#77)
 - fix: YAML compiler logs parse errors at ERROR level with filename — non-ASCII/invalid UTF-8 in pipeline YAML previously failed silently, blocking all workflows in the repo (#95)
 - fix: unknown /api/* paths now return 404 JSON instead of SPA HTML — prevents client tools from silently parsing HTML as API response (#27)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: pipeline status stays 'running' while any workflow is still executing — previously a canceled cleanup workflow could collapse a running compile to 'killed' (#111)
 - feat: woodpecker-deploy.sh auto-rotates JWT secret and API token on every deploy — eliminates manual token rotation after server restarts (#92)
 - fix: queue logs debug-level reason when task skipped in filterWaiting/ShouldRun — surfaces root cause for pts-build-cleanup skips on manual trigger (#162)
 - fix: agent now detects Unauthenticated (JWT expired/rotated) at WS connect time and deletes stale agent.conf — previously looped forever on sql: no rows without self-healing (#77)

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: YAML compiler logs parse errors at ERROR level with filename — non-ASCII/invalid UTF-8 in pipeline YAML previously failed silently, blocking all workflows in the repo (#95)
 - fix: unknown /api/* paths now return 404 JSON instead of SPA HTML — prevents client tools from silently parsing HTML as API response (#27)
 - feat: dual-emit ci_* aliases for Woodpecker server metrics — Grafana dashboards can migrate from woodpecker_* prefix without gaps (#173)
 

--- a/cmd/agent/core/agent.go
+++ b/cmd/agent/core/agent.go
@@ -243,16 +243,31 @@ func run(ctx context.Context, c *cli.Command, backends []types.Backend) error {
 		// Stale conf: AgentID in agent.conf no longer exists in the server DB
 		// (server restart clears agents). Delete the conf so the next systemd
 		// restart re-registers fresh instead of crash-looping on the same ID. (#101)
+		// Also handles WS transport 401 (JWT expired/rotated) where status.FromError
+		// returns ok=false because the failure is at the HTTP upgrade layer, not gRPC. (#77)
+		errMsg := err.Error()
+		isStaleConf := false
 		if s, ok := status.FromError(err); ok {
 			msg := s.Message()
 			if strings.Contains(msg, "AgentID not found") ||
 				strings.Contains(msg, "sql: no rows") ||
 				strings.Contains(msg, "token is expired") {
-				if agentConfigPath != "" {
-					if removeErr := os.Remove(agentConfigPath); removeErr == nil {
-						log.Warn().Str("path", agentConfigPath).Msg("removed stale agent.conf — next start will re-register (#101)")
-					}
-				}
+				isStaleConf = true
+			}
+		}
+		// WS transport: HTTP 401/403 from the upgrade handshake arrives as a plain error (#77)
+		if strings.Contains(errMsg, "401") ||
+			strings.Contains(errMsg, "403") ||
+			strings.Contains(errMsg, "Unauthorized") ||
+			strings.Contains(errMsg, "authentication failed") {
+			isStaleConf = true
+		}
+		if status.Code(err) == codes.Unauthenticated {
+			isStaleConf = true
+		}
+		if isStaleConf && agentConfigPath != "" {
+			if removeErr := os.Remove(agentConfigPath); removeErr == nil {
+				log.Warn().Str("path", agentConfigPath).Msg("removed stale agent.conf — next start will re-register (#77/#101)")
 			}
 		}
 		return err

--- a/cmd/server/metrics_server.go
+++ b/cmd/server/metrics_server.go
@@ -33,35 +33,70 @@ func startMetricsCollector(ctx context.Context, _store store.Store) {
 		Name:      "pending_steps",
 		Help:      "Total number of pending pipeline steps.",
 	})
+	ciPendingSteps := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "pending_steps",
+		Help:      "Total number of pending pipeline steps (ci_* alias for woodpecker_pending_steps, #173).",
+	})
 	waitingSteps := prometheus_auto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "waiting_steps",
 		Help:      "Total number of pipeline waiting on deps.",
+	})
+	ciWaitingSteps := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "waiting_steps",
+		Help:      "Total number of pipeline waiting on deps (ci_* alias for woodpecker_waiting_steps, #173).",
 	})
 	runningSteps := prometheus_auto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "running_steps",
 		Help:      "Total number of running pipeline steps.",
 	})
+	ciRunningSteps := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "running_steps",
+		Help:      "Total number of running pipeline steps (ci_* alias for woodpecker_running_steps, #173).",
+	})
 	workers := prometheus_auto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "worker_count",
 		Help:      "Total number of workers.",
+	})
+	ciWorkers := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "worker_count",
+		Help:      "Total number of workers (ci_* alias for woodpecker_worker_count, #173).",
 	})
 	pipelines := prometheus_auto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "pipeline_total_count",
 		Help:      "Total number of pipelines.",
 	})
+	ciPipelines := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "pipeline_total_count",
+		Help:      "Total number of pipelines (ci_* alias for woodpecker_pipeline_total_count, #173).",
+	})
 	users := prometheus_auto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "user_count",
 		Help:      "Total number of users.",
 	})
+	ciUsers := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "user_count",
+		Help:      "Total number of users (ci_* alias for woodpecker_user_count, #173).",
+	})
 	repos := prometheus_auto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "woodpecker",
 		Name:      "repo_count",
 		Help:      "Total number of repos.",
+	})
+	ciRepos := prometheus_auto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "ci",
+		Name:      "repo_count",
+		Help:      "Total number of repos (ci_* alias for woodpecker_repo_count, #173).",
 	})
 
 	go func() {
@@ -70,9 +105,13 @@ func startMetricsCollector(ctx context.Context, _store store.Store) {
 		for {
 			stats := server.Config.Services.Queue.Info(ctx)
 			pendingSteps.Set(float64(stats.Stats.Pending))
+			ciPendingSteps.Set(float64(stats.Stats.Pending))
 			waitingSteps.Set(float64(stats.Stats.WaitingOnDeps))
+			ciWaitingSteps.Set(float64(stats.Stats.WaitingOnDeps))
 			runningSteps.Set(float64(stats.Stats.Running))
+			ciRunningSteps.Set(float64(stats.Stats.Running))
 			workers.Set(float64(stats.Stats.Workers))
+			ciWorkers.Set(float64(stats.Stats.Workers))
 
 			select {
 			case <-ctx.Done():
@@ -90,8 +129,11 @@ func startMetricsCollector(ctx context.Context, _store store.Store) {
 			userCount, userErr := _store.GetUserCount()
 			pipelineCount, pipelineErr := _store.GetPipelineCount()
 			pipelines.Set(float64(pipelineCount))
+			ciPipelines.Set(float64(pipelineCount))
 			users.Set(float64(userCount))
+			ciUsers.Set(float64(userCount))
 			repos.Set(float64(repoCount))
+			ciRepos.Set(float64(repoCount))
 
 			if err := errors.Join(repoErr, userErr, pipelineErr); err != nil {
 				log.Error().Err(err).Msg("could not update store information for metrics")

--- a/pipeline/frontend/yaml/parse.go
+++ b/pipeline/frontend/yaml/parse.go
@@ -15,6 +15,9 @@
 package yaml
 
 import (
+	"fmt"
+	"unicode/utf8"
+
 	"codeberg.org/6543/xyaml"
 
 	"go.woodpecker-ci.org/woodpecker/v3/pipeline/frontend/yaml/types"
@@ -22,6 +25,9 @@ import (
 
 // ParseBytes parses the configuration from bytes b.
 func ParseBytes(b []byte) (*types.Workflow, error) {
+	if !utf8.Valid(b) {
+		return nil, fmt.Errorf("pipeline YAML contains invalid UTF-8 bytes — check for non-ASCII characters (#95)")
+	}
 	out := new(types.Workflow)
 	err := xyaml.Unmarshal(b, out)
 	if err != nil {

--- a/scripts/woodpecker/woodpecker-deploy.sh
+++ b/scripts/woodpecker/woodpecker-deploy.sh
@@ -204,6 +204,64 @@ if [ -f "${AGENT_ENV}" ]; then
     fi
 fi
 
+# ── Auto-rotate JWT secret and API token (#92) ──
+echo "$(date -u +%FT%TZ) woodpecker-deploy: rotating JWT secret and API token..."
+
+NEW_JWT_SECRET=$(openssl rand -hex 32)
+
+# Update EnvironmentFile so woodpecker-server picks up the new secret on next restart
+if grep -q "^WOODPECKER_JWT_SECRET=" /etc/woodpecker/secrets.env 2>/dev/null; then
+    sed -i "s|^WOODPECKER_JWT_SECRET=.*|WOODPECKER_JWT_SECRET=${NEW_JWT_SECRET}|" /etc/woodpecker/secrets.env
+else
+    echo "WOODPECKER_JWT_SECRET=${NEW_JWT_SECRET}" >> /etc/woodpecker/secrets.env
+fi
+
+# Store new JWT secret in GCP SM
+gcloud secrets versions add woodpecker--jwt-secret \
+    --data-file=<(printf '%s' "${NEW_JWT_SECRET}") \
+    --project=ci-runners-de 2>/dev/null || \
+gcloud secrets create woodpecker--jwt-secret \
+    --data-file=<(printf '%s' "${NEW_JWT_SECRET}") \
+    --project=ci-runners-de
+
+# Restart server to pick up new JWT secret; wait for healthy
+systemctl restart woodpecker-server
+JWT_HEALTH_DEADLINE=$(( $(date +%s) + HEALTH_BUDGET ))
+while true; do
+    if [ "$(date +%s)" -gt "${JWT_HEALTH_DEADLINE}" ]; then
+        slack ":warning:" "JWT rotation: server did not come healthy after secret rotation — manual check required (#92)"
+        break
+    fi
+    RUNNING_VERSION=$(healthz_version)
+    if [ "${RUNNING_VERSION}" = "${VERSION}" ]; then
+        break
+    fi
+    sleep 3
+done
+
+# Refresh the API token by calling the server's own endpoint (user ID 1).
+# The API token is signed with user.Hash (stored in DB), not WOODPECKER_JWT_SECRET,
+# so we ask the server to sign a fresh one rather than constructing it here.
+EXISTING_API_TOKEN=$(gcloud secrets versions access latest --secret="woodpecker-api-token" --project=ci-runners-de 2>/dev/null || echo "")
+if [ -n "${EXISTING_API_TOKEN}" ]; then
+    NEW_API_TOKEN=$(curl -sf --max-time 10 -X POST \
+        -H "Authorization: Bearer ${EXISTING_API_TOKEN}" \
+        "http://localhost:8000/api/user/token" 2>/dev/null || echo "")
+    if [ -n "${NEW_API_TOKEN}" ]; then
+        gcloud secrets versions add woodpecker-api-token \
+            --data-file=<(printf '%s' "${NEW_API_TOKEN}") \
+            --project=ci-runners-de 2>/dev/null || \
+        gcloud secrets create woodpecker-api-token \
+            --data-file=<(printf '%s' "${NEW_API_TOKEN}") \
+            --project=ci-runners-de
+        echo "$(date -u +%FT%TZ) woodpecker-deploy: JWT secret and API token rotated successfully (#92)"
+    else
+        slack ":warning:" "JWT rotation: could not refresh API token from /api/user/token — old token may have expired; manual rotation needed (#92)"
+    fi
+else
+    slack ":warning:" "JWT rotation: woodpecker-api-token not found in GCP SM — skipping API token refresh (#92)"
+fi
+
 # Remove pending marker
 gsutil -q rm "${DEPLOY_BUCKET}/pending" 2>/dev/null || true
 

--- a/server/pipeline/pipeline_status.go
+++ b/server/pipeline/pipeline_status.go
@@ -30,9 +30,19 @@ import (
 // yielded StatusPartial after #28 introduced the success+killed → partial
 // rule (one killed workflow is not "partial" — partial requires at least one
 // actual success AND at least one killed).
+//
+// Guard: if any workflow is still active (running or pending), the pipeline
+// must remain StatusRunning — a canceled cleanup step must not collapse a
+// still-executing compile to killed/partial (#111).
 func PipelineStatus(workflows []*model.Workflow) model.StatusValue {
 	if len(workflows) == 0 {
 		return model.StatusSuccess
+	}
+
+	for _, w := range workflows {
+		if w.State == model.StatusRunning || w.State == model.StatusPending {
+			return model.StatusRunning
+		}
 	}
 
 	status := workflows[0].State

--- a/server/pipeline/stepbuilder/step_builder.go
+++ b/server/pipeline/stepbuilder/step_builder.go
@@ -134,6 +134,7 @@ func (b *StepBuilder) genItemForWorkflow(workflow *model.Workflow, axis matrix.A
 	// parse yaml pipeline
 	parsed, err := yaml.ParseString(substituted)
 	if err != nil {
+		log.Error().Err(err).Str("file", workflow.Name).Str("repo", b.Repo.FullName).Msg("YAML parse error (#95)")
 		return nil, &pipeline_errors.PipelineError{Message: err.Error(), Type: pipeline_errors.PipelineErrorTypeCompiler}
 	}
 

--- a/server/queue/fifo.go
+++ b/server/queue/fifo.go
@@ -323,7 +323,7 @@ func (q *fifo) filterWaiting() {
 	for element := q.pending.Front(); element != nil; element = element.Next() {
 		task, _ := element.Value.(*model.Task)
 		if q.depsInQueue(task) {
-			log.Debug().Msgf("queue: waiting due to unmet dependencies %v", task.ID)
+			log.Debug().Str("task_id", task.ID).Strs("run_on", task.RunOn).Any("dep_status", task.DepStatus).Msg("filterWaiting: task skipped — unmet deps (#162)")
 			q.waitingOnDeps.PushBack(task)
 			filtered = append(filtered, element)
 		}

--- a/server/router/api.go
+++ b/server/router/api.go
@@ -15,6 +15,8 @@
 package router
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog"
 
@@ -276,6 +278,11 @@ func apiRoutes(e *gin.RouterGroup) {
 
 		// Plugin routes — each StatusHook owns a sub-path under /api/plugins/<name>/
 		registerPluginRoutes(apiBase)
+
+		// Unknown /api/* paths → 404 JSON, not SPA HTML (#27)
+		apiBase.Any("/*path", func(c *gin.Context) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "not found", "path": c.Request.URL.Path})
+		})
 	}
 }
 

--- a/server/rpc/rpc.go
+++ b/server/rpc/rpc.go
@@ -102,6 +102,8 @@ func (s *RPC) Next(c context.Context, agentFilter rpc.Filter) (*rpc.Workflow, er
 			return workflow, err
 		}
 
+		log.Debug().Str("task_id", task.ID).Strs("run_on", task.RunOn).Any("dep_status", task.DepStatus).Msg("ShouldRun: false — skipping task (#162)")
+
 		// task should not run, so mark it as done
 		if err := s.Done(c, task.ID, rpc.WorkflowState{}); err != nil {
 			log.Error().Err(err).Msgf("marking workflow task '%s' as done failed", task.ID)


### PR DESCRIPTION
## Summary

Eight ready-to-work issues shipped as a single batch:

- **#173**: ci_* metric aliases for Woodpecker server metrics (Grafana migration prep)
- **#27**: Unknown /api/* paths return 404 JSON not SPA HTML
- **#95**: YAML parse errors logged at ERROR level with filename; invalid UTF-8 detected early
- **#77**: Agent deletes stale conf on Unauthenticated error at WS connect (extends #101 to cover HTTP 401 transport errors)
- **#162**: Queue logs debug-level skip reason in filterWaiting/ShouldRun
- **#92**: woodpecker-deploy.sh auto-rotates JWT secret + API token on every deploy
- **#111**: Pipeline stays 'running' while any workflow still executing (canceled cleanup can't collapse running compile to killed)
- **#116**: Agent proactive idle reconnect at 75% JWT token lifetime (already present in agent.go; RELEASE_NOTES entry added)

## Test plan

- [ ] `go build ./...` passes (no errors beyond expected web asset error)
- [ ] `go vet ./...` passes
- [ ] `go test ./server/pipeline/... ./server/queue/... ./cmd/agent/...` passes
- [ ] Manual: hit unknown /api/xxx path, verify 404 JSON response
- [ ] pts-build triggers and cleanup runs normally (regression check for #111, #162)
- [ ] woodpecker-deploy.sh rotation block executes without error on d3ci42 (check deploy log after next pts-build deploy)
- [ ] Grafana: verify both `woodpecker_pending_steps` and `ci_pending_steps` metrics appear after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)