### PR TITLE
docs: retire stale pentest-dev-vm reference → ephemeral pts-build-vm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ pipeline/    pipeline execution engine
 shared/      common types, config, utils
 
 .woodpecker/
-  pts-build.yaml         compile the fork on pentest-dev-vm
+  pts-build.yaml         compile the fork on an ephemeral pts-build-vm
   pts-ci.yaml            Peregrine-specific CI
   pts-build-compile.yaml build step
   pts-build-cleanup.yaml cleanup step


### PR DESCRIPTION
The persistent `pentest-dev-vm` build host is gone. `pts-build` provisions its own **ephemeral `pts-build-vm`** per run (`pts-wake.sh`: `gcloud compute instances create`, TTL-labeled, deleted in `pts-build-cleanup`). This corrects the Structure note in `CLAUDE.md` so the doc matches reality.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)